### PR TITLE
Add parameter for ImageMagick converter path

### DIFF
--- a/app/config/config.yml
+++ b/app/config/config.yml
@@ -117,3 +117,8 @@ hwi_oauth:
 
 elcodi_bamboo:
     store_tracker: 7s89da7s8d9a
+
+elcodi_media:
+    images:
+        resize:
+            converter_bin_path: %imagick_convert_bin_path%

--- a/app/config/parameters.yml.dist
+++ b/app/config/parameters.yml.dist
@@ -33,3 +33,5 @@ parameters:
     aws_region: us-east-1
 
     bamboo_bucket_name: fillme
+
+    imagick_convert_bin_path: /usr/bin/convert


### PR DESCRIPTION
This fixes path problems with Ubuntu/OS X different paths of ImageMagick installation.