### PR TITLE
One time login using authenticator

### DIFF
--- a/app/config/firewalls.yml
+++ b/app/config/firewalls.yml
@@ -49,6 +49,8 @@ security:
             #context: admin_context
             provider: adminuser
             pattern: ^/%bamboo_admin_prefix%?.*$
+            simple-preauth:
+                authenticator: admin.user.security.one_time_login_authenticator
             form_login:
                 login_path: admin_login
                 check_path: admin_login_check

--- a/src/Elcodi/Admin/UserBundle/DependencyInjection/AdminUserExtension.php
+++ b/src/Elcodi/Admin/UserBundle/DependencyInjection/AdminUserExtension.php
@@ -59,6 +59,7 @@ class AdminUserExtension extends AbstractExtension
             'classes',
             'formTypes',
             'eventListeners',
+            'services',
         ];
     }
 

--- a/src/Elcodi/Admin/UserBundle/Resources/config/classes.yml
+++ b/src/Elcodi/Admin/UserBundle/Resources/config/classes.yml
@@ -15,3 +15,8 @@ parameters:
     admin.user.form_type.password_recover.class: Elcodi\Admin\UserBundle\Form\Type\PasswordRecoverType
     admin.user.form_type.customer.class: Elcodi\Admin\UserBundle\Form\Type\CustomerType
     admin.user.form_type.admin_user.class: Elcodi\Admin\UserBundle\Form\Type\AdminUserType
+
+    #
+    # Authenticators
+    #
+    admin.user.security.one_time_login_authenticator.class: Elcodi\Admin\UserBundle\Security\OneTimeLoginAuthenticator

--- a/src/Elcodi/Admin/UserBundle/Resources/config/services.yml
+++ b/src/Elcodi/Admin/UserBundle/Resources/config/services.yml
@@ -1,0 +1,10 @@
+services:
+
+    #
+    # Authenticator
+    #
+    admin.user.security.one_time_login_authenticator:
+        class: %admin.user.security.one_time_login_authenticator.class%
+        arguments:
+            - @elcodi.object_manager.admin_user
+            - @elcodi.repository.admin_user

--- a/src/Elcodi/Admin/UserBundle/Security/OneTimeLoginAuthenticator.php
+++ b/src/Elcodi/Admin/UserBundle/Security/OneTimeLoginAuthenticator.php
@@ -1,0 +1,131 @@
+<?php
+
+/*
+ * This file is part of the Elcodi package.
+ *
+ * Copyright (c) 2014 Elcodi.com
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ *
+ * Feel free to edit as you please, and have fun.
+ *
+ * @author Marc Morera <yuhu@mmoreram.com>
+ * @author Aldo Chiecchia <zimage@tiscali.it>
+ */
+
+namespace Elcodi\Admin\UserBundle\Security;
+
+use Doctrine\Common\Persistence\ObjectManager;
+use Doctrine\Common\Persistence\ObjectRepository;
+use Symfony\Component\HttpFoundation\Request;
+use Symfony\Component\Security\Core\Authentication\SimplePreAuthenticatorInterface;
+use Symfony\Component\Security\Core\Authentication\Token\PreAuthenticatedToken;
+use Symfony\Component\Security\Core\Authentication\Token\TokenInterface;
+use Symfony\Component\Security\Core\Exception\AuthenticationException;
+use Symfony\Component\Security\Core\Exception\BadCredentialsException;
+use Symfony\Component\Security\Core\User\UserProviderInterface;
+
+/**
+ * Class OneTimeLoginAuthenticator responsible of checking the request for a login hash and login the user in this case.
+ *
+ * @package Elcodi\Admin\UserBundle\Security
+ */
+class OneTimeLoginAuthenticator implements SimplePreAuthenticatorInterface
+{
+    /**
+     * The Admin user repository object.
+     *
+     * @var ObjectRepository
+     */
+    protected $adminUserObjectRepository;
+
+    /**
+     * The admin user manager object.
+     *
+     * @var ObjectManager
+     */
+    private $adminUserManager;
+
+    /**
+     * Generates a new OneTimeLoginAuthenticator injecting it's dependencies.
+     *
+     * @param ObjectManager    $adminUserManager          The admin user manager object.
+     * @param ObjectRepository $adminUserObjectRepository The Admin user repository object.
+     */
+    public function __construct(ObjectManager $adminUserManager, ObjectRepository $adminUserObjectRepository)
+    {
+        $this->adminUserObjectRepository = $adminUserObjectRepository;
+        $this->adminUserManager = $adminUserManager;
+    }
+
+    /**
+     * Creates a token with the login key received on the query parameter.
+     *
+     * @param Request $request     The current request.
+     * @param string  $providerKey The security providerKey (The firewall security area)
+     *
+     * @return PreAuthenticatedToken A pre-authenticated token with the login key received.
+     */
+    public function createToken(Request $request, $providerKey)
+    {
+        $loginKey = $request->query->get('login-key');
+
+        if (!$loginKey) {
+            throw new BadCredentialsException('No login key found');
+        }
+
+        return new PreAuthenticatedToken(
+            'anon.',
+            $loginKey,
+            $providerKey
+        );
+    }
+
+    /**
+     * Authenticate the received token and returns an authenticated token.
+     *
+     * @param TokenInterface        $token        The token generated with the login key.
+     * @param UserProviderInterface $userProvider A user provider.
+     * @param string                $providerKey  The security providerKey (The firewall security area)
+     *
+     * @return PreAuthenticatedToken A pre-authenticated token generated using the user admin entity.
+     */
+    public function authenticateToken(TokenInterface $token, UserProviderInterface $userProvider, $providerKey)
+    {
+        $loginKey = $token->getCredentials();
+
+        $user = $this->adminUserObjectRepository->findOneBy([
+            'oneTimeLoginHash' => $loginKey,
+        ]);
+
+        if (!$user) {
+            throw new AuthenticationException(
+                sprintf('Login Key "%s" does not exist.', $loginKey)
+            );
+        }
+
+        $user->setOneTimeLoginHash(null);
+        $this->adminUserManager->flush();
+
+        return new PreAuthenticatedToken(
+            $user,
+            $loginKey,
+            $providerKey,
+            $user->getRoles()
+        );
+    }
+
+    /**
+     * Checks if the received token is a pre authenticated token.
+     *
+     * @param TokenInterface $token       The token received.
+     * @param string         $providerKey The security providerKey (The firewall security area)
+     *
+     * @return bool Returns true if the received token is of the expected type and for the provider key we are using.
+     */
+    public function supportsToken(TokenInterface $token, $providerKey)
+    {
+        return $token instanceof PreAuthenticatedToken && $token->getProviderKey() === $providerKey;
+    }
+}


### PR DESCRIPTION
Adding one time login authenticator and setting it on the Security config.

This authenticator checks every time that the user tryies to access the admin zone if a **login-key** has been received on the query parameters and if this key is set as "one time login hash" on a user it logs in the current user into the admin panel.

Ping @elcodi/owners 