### PR TITLE
Add the php5-redis extension as a requirement.

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -32,7 +32,8 @@
     ],
     "require": {
         "php": ">=5.4",
-
+        "ext-redis": "*",
+        
         "symfony/symfony": "~2.6",
         "symfony/assetic-bundle": "~2.5",
         "symfony/swiftmailer-bundle": "~2.3",


### PR DESCRIPTION
Solves "Attempted to load class "Redis" from the global namespace. Did you forget a "use" statement? ." issue when doing a new install.