### PR TITLE
Persistent pages

### DIFF
--- a/src/Elcodi/Admin/PageBundle/Controller/PageController.php
+++ b/src/Elcodi/Admin/PageBundle/Controller/PageController.php
@@ -24,10 +24,12 @@ use Sensio\Bundle\FrameworkExtraBundle\Configuration\Template;
 use Symfony\Component\Form\FormInterface;
 use Symfony\Component\HttpFoundation\RedirectResponse;
 use Symfony\Component\HttpFoundation\Request;
+use Symfony\Component\HttpKernel\Exception\AccessDeniedHttpException;
 
 use Elcodi\Admin\CoreBundle\Controller\Abstracts\AbstractAdminController;
 use Elcodi\Component\Core\Entity\Interfaces\EnabledInterface;
 use Elcodi\Component\Page\Entity\Interfaces\PageInterface;
+use Elcodi\Component\Page\Entity\Page;
 
 /**
  * Class Controller for Page
@@ -170,7 +172,7 @@ class PageController extends AbstractAdminController
      * Enable entity
      *
      * @param Request          $request Request
-     * @param EnabledInterface $entity  Entity to enable
+     * @param EnabledInterface $page    Entity to enable
      *
      * @return array Result
      *
@@ -189,12 +191,17 @@ class PageController extends AbstractAdminController
      */
     public function enableAction(
         Request $request,
-        EnabledInterface $entity
+        EnabledInterface $page
     )
     {
+        if ($page->isPersistent()) {
+            $exception = new AccessDeniedHttpException('This page can\'t be accessed for a permanent page');
+            return $this->getFailResponse($request, $exception);
+        }
+
         return parent::enableAction(
             $request,
-            $entity
+            $page
         );
     }
 
@@ -202,7 +209,7 @@ class PageController extends AbstractAdminController
      * Disable entity
      *
      * @param Request          $request Request
-     * @param EnabledInterface $entity  Entity to disable
+     * @param EnabledInterface $page    Entity to disable
      *
      * @return array Result
      *
@@ -221,12 +228,17 @@ class PageController extends AbstractAdminController
      */
     public function disableAction(
         Request $request,
-        EnabledInterface $entity
+        EnabledInterface $page
     )
     {
+        if ($page->isPersistent()) {
+            $exception = new AccessDeniedHttpException('This page can\'t be accessed for a permanent page');
+            return $this->getFailResponse($request, $exception);
+        }
+
         return parent::disableAction(
             $request,
-            $entity
+            $page
         );
     }
 

--- a/src/Elcodi/Admin/PageBundle/Form/EventListener/PermanentPageSubscriber.php
+++ b/src/Elcodi/Admin/PageBundle/Form/EventListener/PermanentPageSubscriber.php
@@ -1,0 +1,54 @@
+<?php
+
+/*
+ * This file is part of the Elcodi package.
+ *
+ * Copyright (c) 2014 Elcodi.com
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ *
+ * Feel free to edit as you please, and have fun.
+ *
+ * @author Marc Morera <yuhu@mmoreram.com>
+ * @author Aldo Chiecchia <zimage@tiscali.it>
+ */
+
+namespace Elcodi\Admin\PageBundle\Form\EventListener;
+
+use Symfony\Component\EventDispatcher\EventSubscriberInterface;
+use Symfony\Component\Form\FormEvent;
+use Symfony\Component\Form\FormEvents;
+
+/**
+ * Class PermanentPageSubscriber checks if the page that's being handled by the form is persistent to modify the form
+ * fields removing the options that are not present for persistent pages.
+ */
+class PermanentPageSubscriber implements EventSubscriberInterface
+{
+    /**
+     * Gets the events which the class is subscribed to.
+     *
+     * @return array The array of events and methods to call.
+     */
+    public static function getSubscribedEvents()
+    {
+        return [FormEvents::PRE_SET_DATA => 'preSetData'];
+    }
+
+    /**
+     * This method is called during the Form::setData() call and removes the options that are not allowed for persistent
+     * pages.
+     *
+     * @param FormEvent $event The form event launched.
+     */
+    public function preSetData(FormEvent $event)
+    {
+        $page = $event->getData();
+        $form = $event->getForm();
+
+        if (($page instanceof PageInterface) && $page->isPersistent()) {
+            $form->remove('enabled');
+        }
+    }
+}

--- a/src/Elcodi/Admin/PageBundle/Form/Type/PageType.php
+++ b/src/Elcodi/Admin/PageBundle/Form/Type/PageType.php
@@ -16,9 +16,10 @@
 
 namespace Elcodi\Admin\PageBundle\Form\Type;
 
+use Symfony\Component\EventDispatcher\EventSubscriberInterface;
 use Symfony\Component\Form\AbstractType;
 use Symfony\Component\Form\FormBuilderInterface;
-
+use Elcodi\Admin\PageBundle\Form\EventListener\PermanentPageSubscriber;
 use Elcodi\Component\EntityTranslator\EventListener\Traits\EntityTranslatableFormTrait;
 
 /**
@@ -29,6 +30,23 @@ class PageType extends AbstractType
     use EntityTranslatableFormTrait;
 
     /**
+     * A permanent page form event subscriber.
+     *
+     * @var EventSubscriberInterface
+     */
+    protected $permanentPageSubscriber;
+
+    /**
+     * Builds the page edit form.
+     *
+     * @param EventSubscriberInterface $permanentPageSubscriber A permanent page event subscriber.
+     */
+    public function __construct(EventSubscriberInterface $permanentPageSubscriber)
+    {
+        $this->permanentPageSubscriber = $permanentPageSubscriber;
+    }
+
+    /**
      * Buildform function
      *
      * @param FormBuilderInterface $builder the formBuilder
@@ -37,37 +55,38 @@ class PageType extends AbstractType
     public function buildForm(FormBuilderInterface $builder, array $options)
     {
         $builder
-            ->add('title', 'text', array(
+            ->add('title', 'text', [
                 'required' => true,
                 'label'    => 'title',
-            ))
-            ->add('path', 'text', array(
+            ])
+            ->add('path', 'text', [
                 'required' => true,
                 'label'    => 'path',
-            ))
-            ->add('content', 'textarea', array(
+            ])
+            ->add('content', 'textarea', [
                 'required' => true,
                 'label'    => 'content',
-            ))
-            ->add('metaTitle', 'text', array(
+            ])
+            ->add('metaTitle', 'text', [
                 'required' => false,
                 'label'    => 'Metatitle',
-            ))
-            ->add('metaDescription', 'text', array(
+            ])
+            ->add('metaDescription', 'text', [
                 'required' => false,
                 'label'    => 'Metadescription',
-            ))
-            ->add('metaKeywords', 'text', array(
+            ])
+            ->add('metaKeywords', 'text', [
                 'required' => false,
                 'label'    => 'Metakeywords',
-            ))
-            ->add('enabled', 'checkbox', array(
+            ])
+            ->add('enabled', 'checkbox', [
                 'required' => false,
                 'label'    => 'enabled',
-            ))
+            ])
         ;
 
         $builder->addEventSubscriber($this->getEntityTranslatorFormEventListener());
+        $builder->addEventSubscriber($this->permanentPageSubscriber);
     }
 
     /**

--- a/src/Elcodi/Admin/PageBundle/Resources/config/classes.yml
+++ b/src/Elcodi/Admin/PageBundle/Resources/config/classes.yml
@@ -4,3 +4,8 @@ parameters:
     # Entity classes
     #
     elcodi.admin.page.form_type.page.class: Elcodi\Admin\PageBundle\Form\Type\PageType
+
+    #
+    # Event Listeners
+    #
+    elcodi.admin.page.form_event_listener.permanent_page.class: Elcodi\Admin\PageBundle\Form\EventListener\PermanentPageSubscriber

--- a/src/Elcodi/Admin/PageBundle/Resources/config/formTypes.yml
+++ b/src/Elcodi/Admin/PageBundle/Resources/config/formTypes.yml
@@ -7,5 +7,12 @@ services:
         class: %elcodi.admin.page.form_type.page.class%
         tags:
             - { name: form.type, alias: elcodi_admin_page_form_type_page }
+        arguments:
+            permanent_page_subscriber: @elcodi.admin.page.form_event_listener.permanent_page
         calls:
             - [setEntityTranslatorFormEventListener, [@elcodi.entity_translator_form_event_listener]]
+    #
+    # Event Listeners
+    #
+    elcodi.admin.page.form_event_listener.permanent_page:
+         class:  %elcodi.admin.page.form_event_listener.permanent_page.class%

--- a/src/Elcodi/Admin/PageBundle/Resources/views/Page/editComponent.html.twig
+++ b/src/Elcodi/Admin/PageBundle/Resources/views/Page/editComponent.html.twig
@@ -89,6 +89,7 @@
                     </div>
                 </div>
             </details>
+            {% if form.enabled is defined %}
             <div class="grid">
                 <div class="col-1-3">
                     <div class="box-none mb-n pb-m">
@@ -106,6 +107,7 @@
                     </div>
                 </div>
             </div>
+            {% endif %}
         </fieldset>
         <div class="grid">
             <div class="col-1-3">

--- a/src/Elcodi/Fixtures/DataFixtures/ORM/Page/PageData.php
+++ b/src/Elcodi/Fixtures/DataFixtures/ORM/Page/PageData.php
@@ -54,7 +54,8 @@ class PageData extends AbstractFixture
             ->setMetaTitle('About us')
             ->setMetaDescription('About us')
             ->setMetaKeywords('about,us')
-            ->setEnabled(true);
+            ->setEnabled(true)
+            ->setPersistent(true);
 
         $pageObjectManager->persist($aboutUsPage);
         $this->addReference('page-about-us', $aboutUsPage);
@@ -98,7 +99,8 @@ class PageData extends AbstractFixture
             ->setMetaTitle('Terms and conditions')
             ->setMetaDescription('Terms and conditions')
             ->setMetaKeywords('terms, conditions')
-            ->setEnabled(true);
+            ->setEnabled(true)
+            ->setPersistent(true);
 
         $pageObjectManager->persist($termsConditionsPage);
         $this->addReference('page-terms-and-conditions', $termsConditionsPage);


### PR DESCRIPTION
Added the possibility to add "persistent pages" that can be modified but not removed neither disabled.
- Added an event listener to page form so when the form is loaded it does the necessary changes for persistent pages like hide the "enable/disable" button
- If you try to access the url to enable/disable or remove this pages you get an Access denied error
- Added to page fixture so the About us and Terms and conditions pages are generated as "persistent pages"

Ping @elcodi/owners  

**IS BLOCKED BY https://github.com/elcodi/elcodi/pull/493**