### PR TITLE
Multiple fixes on category edit parent selection

### DIFF
--- a/src/Elcodi/Admin/ProductBundle/Form/Type/CategoryType.php
+++ b/src/Elcodi/Admin/ProductBundle/Form/Type/CategoryType.php
@@ -99,10 +99,6 @@ class CategoryType extends AbstractType
                 'required' => false,
                 'label'    => 'Root Category',
             ])
-            ->add('position', 'integer', [
-                'required' => false,
-                'label'    => 'Position',
-            ])
             ->add('enabled', 'checkbox', [
                 'required' => false,
                 'label'    => 'Visible',

--- a/src/Elcodi/Admin/ProductBundle/Form/Type/CategoryType.php
+++ b/src/Elcodi/Admin/ProductBundle/Form/Type/CategoryType.php
@@ -118,7 +118,7 @@ class CategoryType extends AbstractType
             ->add('parent', 'entity', [
                 'class'         => $this->categoryFactory->getEntityNamespace(),
                 'query_builder' => $this->getAvailableCategories($currentCategoryId),
-                'required'      => false,
+                'required'      => true,
                 'label'         => 'parent',
                 'multiple'      => false,
             ])

--- a/src/Elcodi/Admin/ProductBundle/Form/Type/CategoryType.php
+++ b/src/Elcodi/Admin/ProductBundle/Form/Type/CategoryType.php
@@ -50,16 +50,15 @@ class CategoryType extends AbstractType
     /**
      * Constructor
      *
-     * @param CategoryFactory    $categoryFactory    Category Factory
-     * @param ProductFactory     $productFactory     Product Factory
+     * @param CategoryFactory $categoryFactory Category Factory
+     * @param ProductFactory  $productFactory  Product Factory
      */
     public function __construct(
         CategoryFactory $categoryFactory,
         ProductFactory $productFactory
-    )
-    {
+    ) {
         $this->categoryFactory = $categoryFactory;
-        $this->productFactory = $productFactory;
+        $this->productFactory  = $productFactory;
     }
 
     /**
@@ -116,8 +115,10 @@ class CategoryType extends AbstractType
                 'label'    => 'metaKeywords',
             ])
             ->add('parent', 'entity', [
-                'class'         => $this->categoryFactory->getEntityNamespace(),
-                'query_builder' => $this->getAvailableCategories($currentCategoryId),
+                'class'         => $this->categoryFactory
+                    ->getEntityNamespace(),
+                'query_builder' => $this
+                    ->getAvailableCategories($currentCategoryId),
                 'required'      => true,
                 'label'         => 'parent',
                 'multiple'      => false,
@@ -129,11 +130,14 @@ class CategoryType extends AbstractType
                 'multiple' => true,
             ]);
 
-        $builder->addEventSubscriber($this->getEntityTranslatorFormEventListener());
+        $builder->addEventSubscriber(
+            $this->getEntityTranslatorFormEventListener()
+        );
     }
 
     /**
-     * This method returns a closure used to show only the valid categories to be selected as parent.
+     * This method returns a closure used to show only the valid categories to
+     * be selected as parent.
      *
      * @param integer|null $currentCategoryId The current category id
      *
@@ -141,18 +145,11 @@ class CategoryType extends AbstractType
      */
     protected function getAvailableCategories($currentCategoryId)
     {
-        return function (CategoryRepository $categoryRepository) use ($currentCategoryId) {
-            $queryBuilder = $categoryRepository
-                ->createQueryBuilder('c')
-                ->where('c.root = 1');
-
-            if ($currentCategoryId) {
-                $queryBuilder
-                    ->andWhere('c.id <> :parent_category')
-                    ->setParameter('parent_category', $currentCategoryId);
-            }
-
-            return $queryBuilder;
+        return function (
+            CategoryRepository $categoryRepository
+        ) use ($currentCategoryId) {
+            return $categoryRepository
+                ->getAvailableParentCategoriesQueryBuilder($currentCategoryId);
         };
     }
 

--- a/src/Elcodi/Admin/ProductBundle/Resources/config/formTypes.yml
+++ b/src/Elcodi/Admin/ProductBundle/Resources/config/formTypes.yml
@@ -26,6 +26,7 @@ services:
         arguments:
             category_factory: @elcodi.factory.category
             product_factory: @elcodi.factory.product
+            category_repository: @elcodi.repository.category
         calls:
             - [setEntityTranslatorFormEventListener, [@elcodi.entity_translator_form_event_listener]]
         tags:

--- a/src/Elcodi/Admin/ProductBundle/Resources/config/formTypes.yml
+++ b/src/Elcodi/Admin/ProductBundle/Resources/config/formTypes.yml
@@ -26,7 +26,6 @@ services:
         arguments:
             category_factory: @elcodi.factory.category
             product_factory: @elcodi.factory.product
-            category_repository: @elcodi.repository.category
         calls:
             - [setEntityTranslatorFormEventListener, [@elcodi.entity_translator_form_event_listener]]
         tags:


### PR DESCRIPTION
- Now you can't select the current category as parent category of the category you are currently editing (Inception loop)
- You can't either select a non parent category as parent (Simple level categories heritage)
- Fixed a bug while genereting the url to "see on store" for new categories

Ping @elcodi/owners 