### PR TITLE
Fix: Moving parent children & updating categories

### DIFF
--- a/src/Elcodi/Admin/ProductBundle/Controller/CategoryController.php
+++ b/src/Elcodi/Admin/ProductBundle/Controller/CategoryController.php
@@ -26,6 +26,7 @@ use Symfony\Component\HttpFoundation\RedirectResponse;
 use Symfony\Component\HttpFoundation\Request;
 
 use Elcodi\Admin\CoreBundle\Controller\Abstracts\AbstractAdminController;
+use Elcodi\Admin\ProductBundle\ProductEvents;
 use Elcodi\Component\Core\Entity\Interfaces\EnabledInterface;
 use Elcodi\Component\Product\Entity\Interfaces\CategoryInterface;
 
@@ -129,6 +130,8 @@ class CategoryController extends AbstractAdminController
             $this->flush($category);
 
             $this->addFlash('success','Changes saved');
+
+            $this->get('event_dispatcher')->dispatch(ProductEvents::CATEGORIES_ONCHANGE);
 
             return $this->redirectToRoute('admin_category_edit', [
                 'id' => $category->getId(),

--- a/src/Elcodi/Admin/ProductBundle/ProductEvents.php
+++ b/src/Elcodi/Admin/ProductBundle/ProductEvents.php
@@ -26,5 +26,5 @@ final class ProductEvents
      *
      * event.name : categories.onorderchange
      */
-    const CATEGORIES_ONORDERCHANGE = 'categories.onorderchange';
+    const CATEGORIES_ONCHANGE = 'categories.onchange';
 }

--- a/src/Elcodi/Admin/ProductBundle/Services/CategorySorter.php
+++ b/src/Elcodi/Admin/ProductBundle/Services/CategorySorter.php
@@ -101,7 +101,7 @@ class CategorySorter
         if ($this->sortCategoriesTree($categoriesOrder)) {
             $this->categoryObjectManager->flush();
 
-            $this->eventDispatcher->dispatch(ProductEvents::CATEGORIES_ONORDERCHANGE);
+            $this->eventDispatcher->dispatch(ProductEvents::CATEGORIES_ONCHANGE);
             return true;
         }
 
@@ -137,6 +137,7 @@ class CategorySorter
             } else {
                 $category->setPosition($counter);
                 $category->setRoot(true);
+                $category->setParent(null);
             }
 
             ++$counter;

--- a/src/Elcodi/Store/ProductBundle/EventListener/CategoriesOrderChangeEventListener.php
+++ b/src/Elcodi/Store/ProductBundle/EventListener/CategoriesOrderChangeEventListener.php
@@ -38,9 +38,10 @@ class CategoriesOrderChangeEventListener
     }
 
     /**
-     * This method is called every time that the categories order change, it reloads the categories tree.
+     * This method is called every time that some property that could affect the categories tree is changed and it
+     * reloads the full tree.
      */
-    public function onOrderChange()
+    public function onChange()
     {
         $this->storeCategoryTree->reload();
     }

--- a/src/Elcodi/Store/ProductBundle/Resources/config/eventListeners.yml
+++ b/src/Elcodi/Store/ProductBundle/Resources/config/eventListeners.yml
@@ -8,4 +8,4 @@ services:
         arguments:
             store_category_tree: @store.product.service.store_category_tree
         tags:
-            - { name: kernel.event_listener, event: categories.onorderchange, method: onOrderChange }
+            - { name: kernel.event_listener, event: categories.onchange, method: onChange }


### PR DESCRIPTION
Fixed:
- Bug when moving children category to parent category (The parent was not removed from the moved category)
- Added an "categories on change" event to the admin when editing a category