### PR TITLE
Paymill integration

### DIFF
--- a/app/AppKernel.php
+++ b/app/AppKernel.php
@@ -50,6 +50,7 @@ class AppKernel extends Kernel
             new \PaymentSuite\PaymentCoreBundle\PaymentCoreBundle(),
             new \PaymentSuite\FreePaymentBundle\FreePaymentBundle(),
             new \PaymentSuite\PaypalWebCheckoutBundle\PaypalWebCheckoutBundle(),
+            new \PaymentSuite\PaymillBundle\PaymillBundle(),
             new \HWI\Bundle\OAuthBundle\HWIOAuthBundle(),
             new Snc\RedisBundle\SncRedisBundle(),
 

--- a/app/config/config.yml
+++ b/app/config/config.yml
@@ -104,6 +104,20 @@ paypal_web_checkout:
         order_append: true
         order_append_field: id
 
+paymill:
+    public_key: %paymill_public_key%
+    private_key: %paymill_private_key%
+    payment_success:
+        route: store_order_thanks
+        order_append: true
+        order_append_field: id
+    payment_fail:
+        route: store_checkout_payment_fail
+        order_append: true
+    form:
+        submit_label: Continue
+        submit_css_class: "btn btn-primary"
+
 hwi_oauth:
     firewall_name: %bamboo_store_firewall%
     resource_owners:

--- a/app/config/config_test.yml
+++ b/app/config/config_test.yml
@@ -51,4 +51,3 @@ elcodi_bamboo:
     store_tracker:        '101010101010'
     store_enabled:        true
     store_under_construction:  false
-

--- a/app/config/parameters.yml.dist
+++ b/app/config/parameters.yml.dist
@@ -28,6 +28,9 @@ parameters:
 
     paypal_web_checkout_recipient:          payment-test-facilitator@elcodi.com
 
+    paymill_public_key: 2476404399006243aa65bb1ccd6c43f4
+    paymill_private_key: 56ebd85ae7479627a4f05efa445365d3
+
     aws_access_key_id: fillme
     aws_secret_access_key: fillme
     aws_region: us-east-1

--- a/app/install.sh
+++ b/app/install.sh
@@ -12,8 +12,8 @@ fi
 HOME=$(pwd) sh -c 'composer install --no-interaction'
 
 # Creating database schema and tables
-/usr/bin/php app/console --no-interaction doc:dat:cre
-/usr/bin/php app/console --no-interaction doc:sch:cre
+/usr/bin/env php app/console --no-interaction doc:dat:cre
+/usr/bin/env php app/console --no-interaction doc:sch:cre
 
 # Allowed fixtures go here
 FIXTURES="AdminUser Category Country Currency Manufacturer Page Rates Attribute \
@@ -22,19 +22,19 @@ FIXTURES="AdminUser Category Country Currency Manufacturer Page Rates Attribute 
 for FIXTURE in ${FIXTURES}; do
      FIXTURES_OPTION="${FIXTURES_OPTION} --fixtures=src/Elcodi/Fixtures/DataFixtures/ORM/${FIXTURE}"
 done
-/usr/bin/php app/console --no-interaction doc:fix:load ${FIXTURES_OPTION}
+/usr/bin/env php app/console --no-interaction doc:fix:load ${FIXTURES_OPTION}
 
 # Load and enable templates. See Elcodi\Component\Template\Services\TemplateManager
-/usr/bin/php app/console el:tem:lo
-/usr/bin/php app/console el:tem:enable StoreTemplateBundle
+/usr/bin/env php app/console el:tem:lo
+/usr/bin/env php app/console el:tem:enable StoreTemplateBundle
 
 # Loads elcodi plugins. See Elcodi\Component\Plugin\Services\PluginManager
-/usr/bin/php app/console el:plu:lo
+/usr/bin/env php app/console el:plu:lo
 
 # Enables the store and makes it visible
-/usr/bin/php app/console el:con:set store.enabled 1
-/usr/bin/php app/console el:con:set store.under_construction 0
+/usr/bin/env php app/console el:con:set store.enabled 1
+/usr/bin/env php app/console el:con:set store.under_construction 0
 
 # Assets & Assetic
-/usr/bin/php app/console --no-interaction assets:install web --symlink
-/usr/bin/php app/console --no-interaction assetic:dump
+/usr/bin/env php app/console --no-interaction assets:install web --symlink
+/usr/bin/env php app/console --no-interaction assetic:dump

--- a/composer.json
+++ b/composer.json
@@ -19,6 +19,14 @@
     ],
     "repositories": [
         {
+            "type": "vcs",
+            "url": "git@github.com:alch/PaypalWebCheckoutBundle.git"
+        },
+        {
+            "type": "vcs",
+            "url": "git@github.com:alch/PaymentSuite.git"
+        },
+        {
             "type": "package",
             "package": {
                 "name": "jquery/jquery",
@@ -60,10 +68,9 @@
 
         "mmoreram/controller-extra-bundle": "~1.0",
         "ornicar/gravatar-bundle" : "1.1.2",
-        "paymentsuite/payment-core-bundle": "1.3",
         "knplabs/knp-gaufrette-bundle": "~0.1.0",
-        "paymentsuite/free-payment-bundle": "~1.0@dev",
-        "paymentsuite/paypal-web-checkout-bundle": "dev-master",
+        "paymentsuite/paymentsuite": "dev-feature/correct-versioning",
+        "paymentsuite/paypal-web-checkout-bundle": "dev-feature/correct-versioning",
         "incenteev/composer-parameter-handler": "~2.0",
         "hwi/oauth-bundle": "0.4.*@dev",
         "snc/redis-bundle": "~1.1",

--- a/src/Elcodi/Store/PaymentBridgeBundle/Resources/config/routing.yml
+++ b/src/Elcodi/Store/PaymentBridgeBundle/Resources/config/routing.yml
@@ -5,3 +5,9 @@ freepayment_payment_routes:
 paypal_web_chckout_payment_routes:
     resource: .
     type: paypal_web_checkout
+
+paymentsuite_paymill_bundle:
+    resource: .
+    type:     paymill
+    prefix:   /
+

--- a/src/Elcodi/Store/PaymentBridgeBundle/Resources/config/services.yml
+++ b/src/Elcodi/Store/PaymentBridgeBundle/Resources/config/services.yml
@@ -7,6 +7,7 @@ services:
         class: %store.payment.service.payment_bridge.class%
         arguments:
             order_repository: @elcodi.repository.order
+            cart_wrapper: @elcodi.cart_wrapper
 
     payment.bridge:
         alias: store.payment.service.payment_bridge


### PR DESCRIPTION
Paymill integration

* PaymentBridge uses CartWrapper to get amount
* PaymentBridge fixes to work with Paymill payment suite

With this PR, Bamboo will be using a forked version of `payment suite/paymentsuite` and `paymentsuite/paypal-web-checkout-bundle`. Once [this PR](https://github.com/PaymentSuite/paymentsuite/pull/16) gets merged and tagged we can go back requiring the original sub-packages.
This is also requiring the **full** `paymentsuite/paymentsuite`repository in composer.json (and not subpackages).

`PaymentBridge` should differentiate between `ORDER` and `CART`. Some payment methods require the amount to be there **BEFORE** the creation of the order. As a temporary measure, `getAmount()`and `getCurrency()` check for the existence of an `Order` in the `PaymentBridge`. If it is not present, values from the `Cart` are taken.

`getAmount()` in Bamboo `PaymentBridge` has to return amounts in `floats` (i.e. not integer/cents) since its what the `PaymentBridgeInterface` dictates. Should propose new methods and rationales behind PaymentBridgeInterface.

Added a small tweak in `PaymentBridge::getExtraData()` to compose a string representing the description of the order. It is just the concatenation of the product names. 
