### PR TITLE
Add `api_area` firewall

### DIFF
--- a/app/config/firewalls.yml
+++ b/app/config/firewalls.yml
@@ -8,6 +8,10 @@ security:
             pattern:  ^/(?:css|images|js)/
             security: false
 
+        api_area:
+            pattern:  ^/api/
+            security: false
+
         admin_login_area:
             pattern: ^/%bamboo_admin_prefix%/login$
             anonymous: ~


### PR DESCRIPTION
This makes possible to use comments in admin while the store is disabled or under construction.
No security is added, since is not needed for now, but can be changed.