### PR TITLE
Fixes for Coupon template

### DIFF
--- a/src/Elcodi/Admin/CoreBundle/Resources/views/Forms/fields.html.twig
+++ b/src/Elcodi/Admin/CoreBundle/Resources/views/Forms/fields.html.twig
@@ -100,9 +100,18 @@
 {% endblock time_widget %}
 
 {% block datetime_widget %}
-{% spaceless %}
-        <input {{ block('widget_attributes') }} class="form-control" size="16" type="text" value="{{ value }}" />
-{% endspaceless %}
+    {% spaceless %}
+        {% if widget == 'single_text' %}
+            {{ block('form_widget_simple', { "attr": { "class": "form-control" }}) }}
+        {% else %}
+            <div {{ block('widget_container_attributes') }}>
+                {{ form_errors(form.date) }}
+                {{ form_errors(form.time) }}
+                {{ form_widget(form.date) }}
+                {{ form_widget(form.time) }}
+            </div>
+        {% endif %}
+    {% endspaceless %}
 {% endblock datetime_widget %}
 
 

--- a/src/Elcodi/Admin/CouponBundle/Form/Type/CouponType.php
+++ b/src/Elcodi/Admin/CouponBundle/Form/Type/CouponType.php
@@ -110,28 +110,18 @@ class CouponType extends AbstractPurchasableType
                 'empty_data'  => null,
             ))
             ->add('validFrom', 'datetime', array(
-                'widget'   => 'single_text',
-                'format'   => 'yyyy-MM-dd - HH:mm:ss',
-                'required' => false,
-                'label'    => 'From',
+                'date_widget'  => 'single_text',
+                'date_format'  => 'yyyy-MM-dd',
+                'time_widget'  => 'single_text',
+                'required'     => false,
+                'label'        => 'From',
             ))
             ->add('validTo', 'datetime', array(
-                'widget'   => 'single_text',
-                'format'   => 'yyyy-MM-dd - HH:mm:ss',
-                'required' => false,
-                'label'    => 'to',
-            ))
-            ->add('createdAt', 'datetime', array(
-                'widget'   => 'single_text',
-                'format'   => 'yyyy-MM-dd - HH:mm:ss',
-                'required' => false,
-                'label'    => 'createdAt',
-            ))
-            ->add('updatedAt', 'datetime', array(
-                'widget'   => 'single_text',
-                'format'   => 'yyyy-MM-dd - HH:mm:ss',
-                'required' => false,
-                'label'    => 'updatedAt',
+                'date_widget'  => 'single_text',
+                'date_format'  => 'yyyy-MM-dd',
+                'time_widget'  => 'single_text',
+                'required'     => false,
+                'label'        => 'to',
             ))
             ->add('enabled', 'checkbox', array(
                 'required' => false,

--- a/src/Elcodi/Admin/CouponBundle/Resources/views/Coupon/editComponent.html.twig
+++ b/src/Elcodi/Admin/CouponBundle/Resources/views/Coupon/editComponent.html.twig
@@ -17,6 +17,7 @@
         })
         : url('admin_coupon_save')
     %}
+
     {{ form_start(form, {'action': formAction}) }}
     <fieldset data-tc-modules="form-coupons">
         <div class="grid">
@@ -148,10 +149,6 @@
                     </ol>
                 </div>
             </div>
-        </div>
-        <div class="d-n">
-            {{ form_row(form.createdAt) }}
-            {{ form_row(form.updatedAt) }}
         </div>
         <div class="grid">
             <div class="col-1-3">

--- a/src/Elcodi/Admin/CurrencyBundle/Form/Type/MoneyType.php
+++ b/src/Elcodi/Admin/CurrencyBundle/Form/Type/MoneyType.php
@@ -64,7 +64,10 @@ class MoneyType extends AbstractType
     public function buildForm(FormBuilderInterface $builder, array $options)
     {
         $builder
-            ->add('amount', 'integer')
+            ->add('amount', 'money', [
+                'divisor' => 100,
+                'currency' => false,
+            ])
             ->add('currency', 'entity', [
                 'class'         => 'Elcodi\Component\Currency\Entity\Currency',
                 'query_builder' => function (EntityRepository $repository) {


### PR DESCRIPTION
- remove fields `createdAt` and `updatedAt`
- set money divisor to 100
- datetime fields splitted in two fields