### PR TITLE
Fix default language

### DIFF
--- a/app/config/parameters.yml.dist
+++ b/app/config/parameters.yml.dist
@@ -15,8 +15,7 @@ parameters:
     mailer_password: ~
     mailer_port: ~
 
-
-    locale: en
+    locale: es
     secret: 4acbc300e57d46cb58ac0c629945c17b727f99c8
 
     use_assetic_controller: false


### PR DESCRIPTION
When the default language is not enabled in `elcodi.language`, it's not possible to save entities managed by the `entityTranslator`.