### PR TITLE
Multiple fixes on users pages

### DIFF
--- a/src/Elcodi/Admin/UserBundle/Controller/AdminUserController.php
+++ b/src/Elcodi/Admin/UserBundle/Controller/AdminUserController.php
@@ -25,6 +25,7 @@ use Sensio\Bundle\FrameworkExtraBundle\Configuration\Template;
 use Symfony\Component\Form\FormInterface;
 use Symfony\Component\HttpFoundation\RedirectResponse;
 use Symfony\Component\HttpFoundation\Request;
+use Symfony\Component\HttpKernel\Exception\HttpException;
 
 use Elcodi\Admin\CoreBundle\Controller\Abstracts\AbstractAdminController;
 use Elcodi\Component\Core\Entity\Interfaces\EnabledInterface;
@@ -153,7 +154,7 @@ class AdminUserController extends AbstractAdminController
 
             $this->addFlash('success', 'Changes saved');
 
-            return $this->redirectToRoute('admin_admin_user_list');
+            return $this->redirectToRoute('admin_homepage');
         }
 
         return [
@@ -218,6 +219,19 @@ class AdminUserController extends AbstractAdminController
         Request $request,
         EnabledInterface $entity
     ) {
+        /**
+         * @var AdminUserInterface $user
+         * @var AdminUserInterface $entity
+         */
+        $user = $this->getUser();
+        if ($entity->getId() == $user->getId()) {
+            $message = 'You can\'t disable your admin account';
+            throw new HttpException(
+                403,
+                $message
+            );
+        }
+
         return parent::disableAction(
             $request,
             $entity
@@ -251,6 +265,19 @@ class AdminUserController extends AbstractAdminController
         $entity,
         $redirectUrl = null
     ) {
+        /**
+         * @var AdminUserInterface $user
+         * @var AdminUserInterface $entity
+         */
+        $user = $this->getUser();
+        if ($entity->getId() == $user->getId()) {
+            $message = 'You can\'t delete your admin account';
+            throw new HttpException(
+                403,
+                $message
+            );
+        }
+
         return parent::deleteAction(
             $request,
             $entity,

--- a/src/Elcodi/Admin/UserBundle/Form/Type/AdminUserType.php
+++ b/src/Elcodi/Admin/UserBundle/Form/Type/AdminUserType.php
@@ -71,10 +71,6 @@ class AdminUserType extends AbstractType
     {
         $builder
             ->setMethod('POST')
-            ->add('username', 'text', array(
-                'required' => true,
-                'label'    => 'Username',
-            ))
             ->add('email', 'email', array(
                 'required' => true,
                 'label'    => 'Email',

--- a/src/Elcodi/Admin/UserBundle/Resources/views/AdminUser/editComponent.html.twig
+++ b/src/Elcodi/Admin/UserBundle/Resources/views/AdminUser/editComponent.html.twig
@@ -26,9 +26,6 @@
                 <div class="box">
                     <ol>
                         <li>
-                            {{ form_row(form.username,{'attr': {'placeholder':'e.g. Johndoe'}}) }}
-                        </li>
-                        <li>
                             {{ form_row(form.email,{'attr': {'placeholder':'e.g. john.doe@mail.com'}}) }}
                         </li>
                     </ol>
@@ -63,7 +60,7 @@
                 </div>
             </div>
         </div>
-        <div class="grid">
+        <div class="grid{% if adminUser.id == app.user.id %} hidden{% endif %}">
             <div class="col-1-3">
                 <div class="box-none">
                     <h2 class="fw-n">{{ 'User Status'|trans }}</h2>

--- a/src/Elcodi/Admin/UserBundle/Resources/views/AdminUser/list.html.twig
+++ b/src/Elcodi/Admin/UserBundle/Resources/views/AdminUser/list.html.twig
@@ -11,12 +11,6 @@
     } %}
 {% endblock breadcrumb %}
 
-
-{% block header_actions %}
-    <a href="{{ url("admin_admin_user_new") }}"class="button-primary"><i class="icon-plus"></i> <span>{{ "New admin user"|trans }}</span></a>
-{% endblock header_actions %}
-
-
 {% block content %}
     {{ render(url("admin_admin_user_list_component", {
         'page': page,

--- a/src/Elcodi/Admin/UserBundle/Resources/views/AdminUser/listComponent.html.twig
+++ b/src/Elcodi/Admin/UserBundle/Resources/views/AdminUser/listComponent.html.twig
@@ -39,10 +39,6 @@
         {% endif %}
     </td>
 
-    {% include "@AdminCore/Tables/actions.html.twig" with {
-        entity: entity,
-        class: "admin_user",
-    } %}
 {% endblock table_body_row %}
 
 

--- a/src/Elcodi/Admin/UserBundle/Resources/views/Customer/list.html.twig
+++ b/src/Elcodi/Admin/UserBundle/Resources/views/Customer/list.html.twig
@@ -12,11 +12,6 @@
 {% endblock breadcrumb %}
 
 
-{% block header_actions %}
-    <a href="{{ url("admin_customer_new") }}" class="button-primary"> <i class="icon-plus"></i> <span>{{ "New customer"|trans }}</span></a>
-{% endblock header_actions %}
-
-
 {% block content %}
     {{ render(url("admin_customer_list_component", {
         'page': page,

--- a/src/Elcodi/Fixtures/DataFixtures/ORM/Menu/menus.yml
+++ b/src/Elcodi/Fixtures/DataFixtures/ORM/Menu/menus.yml
@@ -13,28 +13,12 @@ menu_nodes:
         enabled: 1
         subnodes: ~
 
-    bambooadmin_admin_users:
-        name: Administrators
-        code: ~
-        url: admin_admin_user_list
-        enabled: 1
-        subnodes: ~
-
     bambooadmin_customers:
         name: Customers
-        code: ~
+        code: users
         url: admin_customer_list
         enabled: 1
         subnodes: ~
-
-    bambooadmin_users:
-        name: Users
-        code: users
-        url: ~
-        enabled: 1
-        subnodes:
-            - bambooadmin_admin_users
-            - bambooadmin_customers
 
     bambooadmin_products:
         name: Products
@@ -210,7 +194,7 @@ menus:
         subnodes:
             - bambooadmin_dashboard
             - bambooadmin_orders
-            - bambooadmin_users
+            - bambooadmin_customers
             - bambooadmin_catalog
             - bambooadmin_coupons
             - bambooadmin_reports


### PR DESCRIPTION
- Manage admin users disabled
- When updating your profile you are redirected to the dashboard
- Removed add new customer button
- Hidden the disable button for your own admin user
- Forbidden the disable and delete action for the logged admin user