### PR TITLE
Fix behat/mink version

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -110,7 +110,7 @@
         "doctrine/data-fixtures": "~1.0",
         "behat/behat": "~3.0",
         "behat/symfony2-extension": "~2.0",
-        "behat/mink-extension": "~2.0",
+        "behat/mink-extension": "~2.0, >=2.0.1",
         "behat/mink-browserkit-driver": "~1.1",
         "fabpot/php-cs-fixer": "1.4.2",
         "mmoreram/php-formatter": "1.0.4",


### PR DESCRIPTION
Solves dependency on `visitPage` method, only available before `behat/mink-extension: >=2.0.1`