### PR TITLE
twig _shipping-item fix

### DIFF
--- a/src/Elcodi/Template/StoreTemplateBundle/Resources/views/Modules/_shipping-item.html.twig
+++ b/src/Elcodi/Template/StoreTemplateBundle/Resources/views/Modules/_shipping-item.html.twig
@@ -4,7 +4,7 @@
     {% else %}
         {% if cart.cheapestShippingRange is not null %}
             {% set shippingRange = cart.cheapestShippingRange %}
-            <p class="cart-shipping"><span>{{ 'template.store_template_bundle.shipping.carrier'|trans }} ({{ shippingRange.carrier.name }}) {{ "template.store_template_bundle.shipping.from"|trans }} </span> {{ shippingAmount|print_convert_money() }}</p>
+            <p class="cart-shipping"><span>{{ 'template.store_template_bundle.shipping.carrier'|trans }} ({{ shippingRange.carrier.name }}) {{ "template.store_template_bundle.shipping.from"|trans }} </span> {{ shippingRange.price|print_convert_money() }}</p>
         {% elseif cart.deliveryAddress is null  %}
             <p class="message message-info">{{ "template.store_template_bundle.shipping.costs_will_be_calculated_after_address"|trans }}</p>
         {% else %}


### PR DESCRIPTION
Hi,

In the first step of the checkout (address), if you haven't got the shipping info you must show the lower shippingRange instead.

Cheers.