### PR TITLE
Remove app/AppKernel.php from autoloading

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -139,8 +139,7 @@
             "Elcodi\\": [
                 "src/Elcodi"
             ]
-        },
-        "files": ["app/AppKernel.php"]
+        }
     },
     "config": {
         "bin-dir": "bin"


### PR DESCRIPTION
web/app(_dev).php require the file anyway

Doesn’t really make sense imho