### PR TITLE
Changing fiscall address message and help

### DIFF
--- a/src/Elcodi/Admin/CoreBundle/Resources/translations/messages.ca.yml
+++ b/src/Elcodi/Admin/CoreBundle/Resources/translations/messages.ca.yml
@@ -37,7 +37,8 @@ admin:
         single: Adreça fiscal
         plural: Adreçes fiscals
         edit:
-            billing_address: Adreça fiscal de la teva botiga
+            billing_address: Adreça de facturació de la teva botiga
+            description: "La direcció que ha de constar a les factures que la teva tenda emeti. En el cas de tenir una empresa aquesta serà la direcció fiscal d'aquesta. En cas contrari, segurament serà la teva direcció física."
         select:
             placeholder: Sel·lecciona una
         field:

--- a/src/Elcodi/Admin/CoreBundle/Resources/translations/messages.en.yml
+++ b/src/Elcodi/Admin/CoreBundle/Resources/translations/messages.en.yml
@@ -39,7 +39,8 @@ admin:
         plural: Addresses
         saved:  Address saved
         edit:
-            billing_address: Edit billing address
+            billing_address: Billing address for your store
+            description: "The address that should appear on the bills from your store. If you own a company that should be its fiscal address. Otherwise will surely be your physical address."
         select:
             placeholder: Select one
         field:

--- a/src/Elcodi/Admin/CoreBundle/Resources/translations/messages.es.yml
+++ b/src/Elcodi/Admin/CoreBundle/Resources/translations/messages.es.yml
@@ -39,7 +39,8 @@ admin:
         plural: Direcciones fiscales
         saved:  Dirección guardada
         edit:
-            billing_address: Dirección fiscal de tu tienda
+            billing_address: Dirección de facturación de tu tienda
+            description: "La dirección que constará en las facturas que emita tu tienda. En el caso de tener una empresa, esta será la dirección fiscal de esta. En caso contrario seguramente será tu dirección física."
         select:
             placeholder: Selecciona una
         field:

--- a/src/Elcodi/Admin/CoreBundle/Resources/translations/messages.fr.yml
+++ b/src/Elcodi/Admin/CoreBundle/Resources/translations/messages.fr.yml
@@ -38,6 +38,7 @@ admin:
         plural: Adresses
         edit:
             billing_address: Mettre à jour l'adresse de facturation
+            description: ~
         select:
             placeholder: Choisir une option
         field:

--- a/src/Elcodi/Admin/GeoBundle/Resources/views/Address/edit.html.twig
+++ b/src/Elcodi/Admin/GeoBundle/Resources/views/Address/edit.html.twig
@@ -16,6 +16,9 @@
 
 
 {% block content %}
+    <div class="msg-info">
+        {{ 'admin.address.edit.description'|trans }}
+    </div>
 
     {{ form_start(form) }}
     {{ form_row(form.name, { value: 'Store address' }) }}


### PR DESCRIPTION
- Changed fiscal address title to be clearer
- Added help on admin address page

Plase @tonipinel take a look at the markup. I added the help as an info message but you surely can improve this ;) Remove the WiP when this is finished.