### PR TITLE
Fixed violation of dependency inversion in paymentbridge events

### DIFF
--- a/src/Elcodi/Store/PaymentBridgeBundle/EventListener/CartPaidEventListener.php
+++ b/src/Elcodi/Store/PaymentBridgeBundle/EventListener/CartPaidEventListener.php
@@ -17,7 +17,7 @@
 
 namespace Elcodi\Store\PaymentBridgeBundle\EventListener;
 
-use PaymentSuite\PaymentCoreBundle\Event\PaymentOrderLoadEvent;
+use PaymentSuite\PaymentCoreBundle\Event\Abstracts\AbstractPaymentEvent;
 
 use Elcodi\Component\Cart\Transformer\CartOrderTransformer;
 use Elcodi\Component\Cart\Wrapper\CartWrapper;
@@ -59,9 +59,9 @@ class CartPaidEventListener
      * Create order given current cart. This event is only for pushing the new
      * Order to the payment infrastructure
      *
-     * @param PaymentOrderLoadEvent $event Event
+     * @param AbstractPaymentEvent $event Event
      */
-    public function transformCartToOrder(PaymentOrderLoadEvent $event)
+    public function transformCartToOrder(AbstractPaymentEvent $event)
     {
         $cart = $this
             ->cartWrapper

--- a/src/Elcodi/Store/PaymentBridgeBundle/EventListener/OrderToPaidEventListener.php
+++ b/src/Elcodi/Store/PaymentBridgeBundle/EventListener/OrderToPaidEventListener.php
@@ -18,10 +18,10 @@
 namespace Elcodi\Store\PaymentBridgeBundle\EventListener;
 
 use Doctrine\Common\Persistence\ObjectManager;
-use PaymentSuite\PaymentCoreBundle\Event\PaymentOrderSuccessEvent;
 
 use Elcodi\Component\Cart\Entity\Interfaces\OrderInterface;
 use Elcodi\Component\StateTransitionMachine\Machine\MachineManager;
+use PaymentSuite\PaymentCoreBundle\Event\Abstracts\AbstractPaymentEvent;
 
 /**
  * Class OrderToPaidEventListener
@@ -71,9 +71,9 @@ class OrderToPaidEventListener
      *
      * This means that we can change the order state to ACCEPTED
      *
-     * @param PaymentOrderSuccessEvent $event
+     * @param AbstractPaymentEvent $event
      */
-    public function setOrderToPaid(PaymentOrderSuccessEvent $event)
+    public function setOrderToPaid(AbstractPaymentEvent $event)
     {
         $order = $event
             ->getPaymentBridge()


### PR DESCRIPTION
`PaymentBridge` event listeners should not depend on specific `AbstractPaymentEvents` implementations, since it will make it impossible to bind the same listener to a different `Event`