### PR TITLE
Fix dependencies

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -97,7 +97,7 @@
         "elcodi-templates/store-template-bundle": "self.version"
     },
     "require-dev": {
-        "elcodi/elcodi": "0.5.2",
+        "elcodi/elcodi": "0.5.3",
         "elcodi/test-common-bundle": "~0.5.0",
         "doctrine/data-fixtures": "~1.0",
         "behat/behat": "~3.0",

--- a/composer.json
+++ b/composer.json
@@ -22,6 +22,7 @@
         "ext-openssl": "*",
 
         "symfony/symfony": "~2.6",
+        "symfony/framework-bundle": "~2.6, >=2.6.5",
         "symfony/assetic-bundle": "~2.5",
         "symfony/swiftmailer-bundle": "~2.3",
         "symfony/monolog-bundle": "~2.6",


### PR DESCRIPTION
In Symfony 2.6.5, support for `ConfigurationInterface` was added to the console command `config:debug`. We need this for Elcodi's `AbstractConfiguration`.

Also update `bamboo` to depend on latest `elcodi` (0.5.3)