### PR TITLE
Fix `.travis.yml`

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -10,9 +10,8 @@ php:
 matrix:
     fast_finish: true
     allow_failures:
-        - php:
-            - 7.0
-            - hhvm
+        - php: 7.0
+        - php: hhvm
 
 before_install:
     - /home/travis/.phpenv/versions/$(phpenv version-name)/bin/composer self-update


### PR DESCRIPTION
`allow_failures` should be an array of object combinations which will be excluded from the testing matrix validation.