### PR TITLE
Fixed trait and incorrect property

### DIFF
--- a/src/Elcodi/Store/PaymentBridgeBundle/Entity/PaypalTransaction.php
+++ b/src/Elcodi/Store/PaymentBridgeBundle/Entity/PaypalTransaction.php
@@ -37,17 +37,12 @@ class PaypalTransaction
     /**
      * @var string
      */
-    protected $transaction;
+    protected $transactionId;
 
     /**
      * @var Order
      */
     protected $order;
-
-    /**
-     * @var \DateTime
-     */
-    protected $createdAt;
 
     /**
      * @return string


### PR DESCRIPTION
`Elcodi\Store\PaymentBridgeBundle\Entity\PaypalTransaction` was using a trait in conflict with a local property. 
The method `getTransactionId()` was returning an unset property.

This is a fix for #118, a more thorough solution is required, where the payment transaction is **generalized** and can save references to any payment method