### PR TITLE
Remove unused method getRepositoryForClass from AbstractAdminController

### DIFF
--- a/src/Elcodi/Admin/CoreBundle/Controller/Abstracts/AbstractAdminController.php
+++ b/src/Elcodi/Admin/CoreBundle/Controller/Abstracts/AbstractAdminController.php
@@ -267,18 +267,4 @@ class AbstractAdminController extends Controller
             ->get('elcodi.provider.manager')
             ->getManagerByEntityNamespace(get_class($entity));
     }
-
-    /**
-     * Get entity repository from an entity
-     *
-     * @param Mixed $entity Entity
-     *
-     * @return ObjectManager specific manager
-     */
-    private function getRepositoryForClass($entity)
-    {
-        return $this
-            ->get('elcodi.provider.repository')
-            ->getRepositoryByEntityNamespace(get_class($entity));
-    }
 }


### PR DESCRIPTION
I think that happened in 96965fac3b77bece4e4ae82581d0bd010faefd8a