### PR TITLE
Fix redirection deleting images

### DIFF
--- a/src/Elcodi/Admin/AttributeBundle/Controller/AttributeController.php
+++ b/src/Elcodi/Admin/AttributeBundle/Controller/AttributeController.php
@@ -236,9 +236,9 @@ class AttributeController extends AbstractAdminController
     /**
      * Delete entity
      *
-     * @param Request $request     Request
-     * @param mixed   $entity      Entity to delete
-     * @param string  $redirectUrl Redirect url
+     * @param Request $request      Request
+     * @param mixed   $entity       Entity to delete
+     * @param string  $redirectPath Redirect path
      *
      * @return RedirectResponse Redirect response
      *
@@ -258,7 +258,7 @@ class AttributeController extends AbstractAdminController
     public function deleteAction(
         Request $request,
         $entity,
-        $redirectUrl = null
+        $redirectPath = null
     ) {
         return parent::deleteAction(
             $request,

--- a/src/Elcodi/Admin/BannerBundle/Controller/BannerController.php
+++ b/src/Elcodi/Admin/BannerBundle/Controller/BannerController.php
@@ -508,9 +508,9 @@ class BannerController extends AbstractAdminController
     /**
      * Delete entity
      *
-     * @param Request $request     Request
-     * @param mixed   $entity      Entity to delete
-     * @param string  $redirectUrl Redirect url
+     * @param Request $request      Request
+     * @param mixed   $entity       Entity to delete
+     * @param string  $redirectPath Redirect path
      *
      * @return RedirectResponse Redirect response
      *
@@ -530,7 +530,7 @@ class BannerController extends AbstractAdminController
     public function deleteAction(
         Request $request,
         $entity,
-        $redirectUrl = null
+        $redirectPath = null
     ) {
         return parent::deleteAction(
             $request,

--- a/src/Elcodi/Admin/BannerBundle/Controller/BannerZoneController.php
+++ b/src/Elcodi/Admin/BannerBundle/Controller/BannerZoneController.php
@@ -489,9 +489,9 @@ class BannerZoneController extends AbstractAdminController
     /**
      * Delete entity
      *
-     * @param Request $request     Request
-     * @param mixed   $entity      Entity to delete
-     * @param string  $redirectUrl Redirect url
+     * @param Request $request      Request
+     * @param mixed   $entity       Entity to delete
+     * @param string  $redirectPath Redirect path
      *
      * @return RedirectResponse Redirect response
      *
@@ -511,7 +511,7 @@ class BannerZoneController extends AbstractAdminController
     public function deleteAction(
         Request $request,
         $entity,
-        $redirectUrl = null
+        $redirectPath = null
     ) {
         return parent::deleteAction(
             $request,

--- a/src/Elcodi/Admin/CoreBundle/Controller/Abstracts/AbstractAdminController.php
+++ b/src/Elcodi/Admin/CoreBundle/Controller/Abstracts/AbstractAdminController.php
@@ -81,16 +81,16 @@ class AbstractAdminController extends Controller
     /**
      * Updated edited element action
      *
-     * @param Request $request     Request
-     * @param Mixed   $entity      Entity to delete
-     * @param string  $redirectUrl Redirect url
+     * @param Request $request      Request
+     * @param Mixed   $entity       Entity to delete
+     * @param string  $redirectPath Redirect path
      *
      * @return RedirectResponse Redirect response
      */
     protected function deleteAction(
         Request $request,
         $entity,
-        $redirectUrl = null
+        $redirectPath = null
     ) {
         return $this->getResponse($request, function () use ($entity) {
             /**
@@ -107,7 +107,7 @@ class AbstractAdminController extends Controller
                     ->trans('ui.delete.success')
             );
 
-        }, $redirectUrl);
+        }, $redirectPath);
     }
 
     /**
@@ -136,9 +136,9 @@ class AbstractAdminController extends Controller
      *
      * This method takes into account the type of the request ( GET or POST )
      *
-     * @param Request $request     Request
-     * @param Closure $closure     Closure
-     * @param string  $redirectUrl Redirect url
+     * @param Request $request      Request
+     * @param Closure $closure      Closure
+     * @param string  $redirectPath Redirect path
      *
      * @return mixed Response
      *
@@ -147,12 +147,15 @@ class AbstractAdminController extends Controller
     protected function getResponse(
         Request $request,
         Closure $closure,
-        $redirectUrl = null
+        $redirectPath = null
     ) {
         try {
             $closure();
 
-            return $this->getOkResponse($request, $redirectUrl);
+            return $this->getOkResponse(
+                $request,
+                $redirectPath
+            );
         } catch (Exception $exception) {
             return $this->getFailResponse($request, $exception);
         }
@@ -163,23 +166,24 @@ class AbstractAdminController extends Controller
      *
      * This method takes into account the type of the request ( GET or POST )
      *
-     * @param Request $request     Request
-     * @param string  $redirectUrl Redirect url
+     * @param Request $request      Request
+     * @param string  $redirectPath Redirect path
      *
      * @return mixed Response
      */
-    protected function getOkResponse(Request $request, $redirectUrl = null)
-    {
-        if (null === $redirectUrl) {
-            $redirectRoute = $request->headers->get('referer');
-        } elseif ($redirectUrl instanceof Closure) {
-            $redirectRoute = $redirectUrl();
+    protected function getOkResponse(
+        Request $request,
+        $redirectPath = null
+    ) {
+        if (null === $redirectPath) {
+            $redirectUrl = $request->headers->get('referer');
         } else {
-            $redirectRoute = $this->generateUrl($redirectUrl);
+            $redirectUrl = $request
+                ->getUriForPath($redirectPath);
         }
 
         return ('GET' === $request->getMethod())
-            ? $this->redirect($redirectRoute)
+            ? $this->redirect($redirectUrl)
             : new Response(json_encode([
                 'result'  => 'ok',
                 'code'    => '0',

--- a/src/Elcodi/Admin/CoreBundle/Resources/translations/messages.en.yml
+++ b/src/Elcodi/Admin/CoreBundle/Resources/translations/messages.en.yml
@@ -890,6 +890,6 @@ ui:
     language:
         master_language: Master Language (Mandatory)
     delete:
-        success: Deleted correctly
+        success: Correctly deleted
     editor:
         help: Select some text to get some format options

--- a/src/Elcodi/Admin/CouponBundle/Controller/CouponController.php
+++ b/src/Elcodi/Admin/CouponBundle/Controller/CouponController.php
@@ -225,9 +225,9 @@ class CouponController extends AbstractAdminController
     /**
      * Delete entity
      *
-     * @param Request $request     Request
-     * @param mixed   $entity      Entity to delete
-     * @param string  $redirectUrl Redirect url
+     * @param Request $request      Request
+     * @param mixed   $entity       Entity to delete
+     * @param string  $redirectPath Redirect path
      *
      * @return RedirectResponse Redirect response
      *
@@ -247,7 +247,7 @@ class CouponController extends AbstractAdminController
     public function deleteAction(
         Request $request,
         $entity,
-        $redirectUrl = null
+        $redirectPath = null
     ) {
         return parent::deleteAction(
             $request,

--- a/src/Elcodi/Admin/MediaBundle/Controller/ImageController.php
+++ b/src/Elcodi/Admin/MediaBundle/Controller/ImageController.php
@@ -18,6 +18,7 @@
 namespace Elcodi\Admin\MediaBundle\Controller;
 
 use Mmoreram\ControllerExtraBundle\Annotation\Entity as EntityAnnotation;
+use Mmoreram\ControllerExtraBundle\Annotation\Get;
 use Mmoreram\ControllerExtraBundle\Annotation\JsonResponse;
 use Sensio\Bundle\FrameworkExtraBundle\Configuration\Method;
 use Sensio\Bundle\FrameworkExtraBundle\Configuration\Route;
@@ -122,9 +123,9 @@ class ImageController extends AbstractAdminController
     /**
      * Delete entity
      *
-     * @param Request $request     Request
-     * @param mixed   $entity      Entity to delete
-     * @param string  $redirectUrl Redirect url
+     * @param Request $request      Request
+     * @param mixed   $entity       Entity to delete
+     * @param string  $redirectPath Redirect path
      *
      * @return RedirectResponse Redirect response
      *
@@ -144,12 +145,20 @@ class ImageController extends AbstractAdminController
     public function deleteAction(
         Request $request,
         $entity,
-        $redirectUrl = null
+        $redirectPath = null
     ) {
+        $redirectPathParam = $request
+            ->query
+            ->get('redirect-path');
+
+        $redirectPath = is_null($redirectPathParam)
+            ? $this->generateUrl('admin_image_list')
+            : $redirectPath;
+
         return parent::deleteAction(
             $request,
             $entity,
-            'admin_image_list'
+            $redirectPath
         );
     }
 

--- a/src/Elcodi/Admin/MediaBundle/Resources/views/Module/_images-form-field.html.twig
+++ b/src/Elcodi/Admin/MediaBundle/Resources/views/Module/_images-form-field.html.twig
@@ -32,7 +32,10 @@
                     </a>
                     <ul class="thumbnail-actions">
                         <li>
-                            <a href="{{ url('admin_image_delete', { id: image.id }) }}" class="icon-trash-o"></a>
+                            <a
+                                href="{{ url('admin_image_delete', { id: image.id }) }}{% if redirect_url is defined %}{{ '?redirect-path=' ~ redirect_url }}{% endif %}"
+                                class="icon-trash-o">
+                            </a>
                         </li>
                     </ul>
                 </li>

--- a/src/Elcodi/Admin/MediaBundle/Resources/views/Module/_images-form-field.html.twig
+++ b/src/Elcodi/Admin/MediaBundle/Resources/views/Module/_images-form-field.html.twig
@@ -33,7 +33,7 @@
                     <ul class="thumbnail-actions">
                         <li>
                             <a
-                                href="{{ url('admin_image_delete', { id: image.id }) }}{% if redirect_url is defined %}{{ '?redirect-path=' ~ redirect_url }}{% endif %}"
+                                href="{{ url('admin_image_delete', { id: image.id }) }}{% if redirect_path is defined %}{{ '?redirect-path=' ~ redirect_path }}{% endif %}"
                                 class="icon-trash-o">
                             </a>
                         </li>

--- a/src/Elcodi/Admin/NewsletterBundle/Controller/NewsletterSubscriptionController.php
+++ b/src/Elcodi/Admin/NewsletterBundle/Controller/NewsletterSubscriptionController.php
@@ -316,9 +316,9 @@ class NewsletterSubscriptionController extends AbstractAdminController
     /**
      * Delete entity
      *
-     * @param Request $request     Request
-     * @param mixed   $entity      Entity to delete
-     * @param string  $redirectUrl Redirect url
+     * @param Request $request      Request
+     * @param mixed   $entity       Entity to delete
+     * @param string  $redirectPath Redirect path
      *
      * @return RedirectResponse Redirect response
      *
@@ -339,7 +339,7 @@ class NewsletterSubscriptionController extends AbstractAdminController
     public function deleteAction(
         Request $request,
         $entity,
-        $redirectUrl = null
+        $redirectPath = null
     ) {
         return parent::deleteAction(
             $request,

--- a/src/Elcodi/Admin/PageBundle/Controller/BlogPostController.php
+++ b/src/Elcodi/Admin/PageBundle/Controller/BlogPostController.php
@@ -168,9 +168,9 @@ class BlogPostController extends AbstractAdminController
     /**
      * Delete a blog post
      *
-     * @param Request $request     Request
-     * @param mixed   $entity      Entity to delete
-     * @param string  $redirectUrl Redirect url
+     * @param Request $request      Request
+     * @param mixed   $entity       Entity to delete
+     * @param string  $redirectPath Redirect path
      *
      * @return RedirectResponse Redirect response
      *
@@ -190,7 +190,7 @@ class BlogPostController extends AbstractAdminController
     public function deleteAction(
         Request $request,
         $entity,
-        $redirectUrl = null
+        $redirectPath = null
     ) {
         return parent::deleteAction(
             $request,

--- a/src/Elcodi/Admin/PageBundle/Controller/PageController.php
+++ b/src/Elcodi/Admin/PageBundle/Controller/PageController.php
@@ -246,9 +246,9 @@ class PageController extends AbstractAdminController
     /**
      * Delete entity
      *
-     * @param Request $request     Request
-     * @param mixed   $entity      Entity to delete
-     * @param string  $redirectUrl Redirect url
+     * @param Request $request      Request
+     * @param mixed   $entity       Entity to delete
+     * @param string  $redirectPath Redirect path
      *
      * @return RedirectResponse Redirect response
      *
@@ -268,7 +268,7 @@ class PageController extends AbstractAdminController
     public function deleteAction(
         Request $request,
         $entity,
-        $redirectUrl = null
+        $redirectPath = null
     ) {
         try {
             $this->canBeDeactivated($entity);

--- a/src/Elcodi/Admin/ProductBundle/Controller/CategoryController.php
+++ b/src/Elcodi/Admin/ProductBundle/Controller/CategoryController.php
@@ -219,9 +219,9 @@ class CategoryController extends AbstractAdminController
     /**
      * Delete entity
      *
-     * @param Request $request     Request
-     * @param mixed   $entity      Entity to delete
-     * @param string  $redirectUrl Redirect url
+     * @param Request $request      Request
+     * @param mixed   $entity       Entity to delete
+     * @param string  $redirectPath Redirect path
      *
      * @return RedirectResponse Redirect response
      *
@@ -241,7 +241,7 @@ class CategoryController extends AbstractAdminController
     public function deleteAction(
         Request $request,
         $entity,
-        $redirectUrl = null
+        $redirectPath = null
     ) {
         return parent::deleteAction(
             $request,

--- a/src/Elcodi/Admin/ProductBundle/Controller/ManufacturerController.php
+++ b/src/Elcodi/Admin/ProductBundle/Controller/ManufacturerController.php
@@ -241,9 +241,9 @@ class ManufacturerController extends AbstractAdminController
     /**
      * Delete entity
      *
-     * @param Request $request     Request
-     * @param mixed   $entity      Entity to delete
-     * @param string  $redirectUrl Redirect url
+     * @param Request $request      Request
+     * @param mixed   $entity       Entity to delete
+     * @param string  $redirectPath Redirect path
      *
      * @return RedirectResponse Redirect response
      *
@@ -263,7 +263,7 @@ class ManufacturerController extends AbstractAdminController
     public function deleteAction(
         Request $request,
         $entity,
-        $redirectUrl = null
+        $redirectPath = null
     ) {
         return parent::deleteAction(
             $request,

--- a/src/Elcodi/Admin/ProductBundle/Controller/ProductController.php
+++ b/src/Elcodi/Admin/ProductBundle/Controller/ProductController.php
@@ -240,9 +240,9 @@ class ProductController extends AbstractAdminController
     /**
      * Delete entity
      *
-     * @param Request $request     Request
-     * @param mixed   $entity      Entity to delete
-     * @param string  $redirectUrl Redirect url
+     * @param Request $request      Request
+     * @param mixed   $entity       Entity to delete
+     * @param string  $redirectPath Redirect path
      *
      * @return RedirectResponse Redirect response
      *
@@ -262,7 +262,7 @@ class ProductController extends AbstractAdminController
     public function deleteAction(
         Request $request,
         $entity,
-        $redirectUrl = null
+        $redirectPath = null
     ) {
         return parent::deleteAction(
             $request,

--- a/src/Elcodi/Admin/ProductBundle/Controller/VariantController.php
+++ b/src/Elcodi/Admin/ProductBundle/Controller/VariantController.php
@@ -233,9 +233,9 @@ class VariantController extends AbstractAdminController
     /**
      * Delete element action
      *
-     * @param Request $request     Request
-     * @param mixed   $variant     Variant to delete
-     * @param string  $redirectUrl Redirect url
+     * @param Request $request      Request
+     * @param mixed   $variant      Variant to delete
+     * @param string  $redirectPath Redirect path
      *
      * @return RedirectResponse Redirect response
      *
@@ -263,7 +263,7 @@ class VariantController extends AbstractAdminController
     public function deleteAction(
         Request $request,
         $variant,
-        $redirectUrl = null
+        $redirectPath = null
     ) {
         /**
          * @var ProductInterface $product

--- a/src/Elcodi/Admin/ProductBundle/Resources/views/Product/editComponent.html.twig
+++ b/src/Elcodi/Admin/ProductBundle/Resources/views/Product/editComponent.html.twig
@@ -177,7 +177,8 @@
             </div>
 
             {% include '@AdminMedia/Module/_images-form-field.html.twig' with {
-            images: product.getSortedImages,
+                images: product.getSortedImages,
+                redirect_url: path('admin_product_edit', { id: product.id })
             } %}
             <div class="ph-n pt-m mb-n">
                 <div class="box-background pv-s mb-n">

--- a/src/Elcodi/Admin/ProductBundle/Resources/views/Product/editComponent.html.twig
+++ b/src/Elcodi/Admin/ProductBundle/Resources/views/Product/editComponent.html.twig
@@ -178,7 +178,7 @@
 
             {% include '@AdminMedia/Module/_images-form-field.html.twig' with {
                 images: product.getSortedImages,
-                redirect_url: path('admin_product_edit', { id: product.id })
+                redirect_path: path('admin_product_edit', { id: product.id })
             } %}
             <div class="ph-n pt-m mb-n">
                 <div class="box-background pv-s mb-n">

--- a/src/Elcodi/Admin/RuleBundle/Controller/RuleController.php
+++ b/src/Elcodi/Admin/RuleBundle/Controller/RuleController.php
@@ -507,9 +507,9 @@ class RuleController extends AbstractAdminController
     /**
      * Delete entity
      *
-     * @param Request $request     Request
-     * @param mixed   $entity      Entity to delete
-     * @param string  $redirectUrl Redirect url
+     * @param Request $request      Request
+     * @param mixed   $entity       Entity to delete
+     * @param string  $redirectPath Redirect path
      *
      * @return RedirectResponse Redirect response
      *
@@ -529,7 +529,7 @@ class RuleController extends AbstractAdminController
     public function deleteAction(
         Request $request,
         $entity,
-        $redirectUrl = null
+        $redirectPath = null
     ) {
         return parent::deleteAction(
             $request,

--- a/src/Elcodi/Admin/ShippingBundle/Controller/CarrierController.php
+++ b/src/Elcodi/Admin/ShippingBundle/Controller/CarrierController.php
@@ -153,9 +153,9 @@ class CarrierController extends AbstractAdminController
     /**
      * Delete entity
      *
-     * @param Request $request     Request
-     * @param mixed   $entity      Entity to delete
-     * @param string  $redirectUrl Redirect url
+     * @param Request $request      Request
+     * @param mixed   $entity       Entity to delete
+     * @param string  $redirectPath Redirect path
      *
      * @return RedirectResponse Redirect response
      *
@@ -175,7 +175,7 @@ class CarrierController extends AbstractAdminController
     public function deleteAction(
         Request $request,
         $entity,
-        $redirectUrl = null
+        $redirectPath = null
     ) {
         return parent::deleteAction(
             $request,

--- a/src/Elcodi/Admin/ShippingBundle/Controller/ShippingRangeController.php
+++ b/src/Elcodi/Admin/ShippingBundle/Controller/ShippingRangeController.php
@@ -143,9 +143,9 @@ class ShippingRangeController extends AbstractAdminController
     /**
      * Delete entity
      *
-     * @param Request $request     Request
-     * @param mixed   $entity      Entity to delete
-     * @param string  $redirectUrl Redirect url
+     * @param Request $request      Request
+     * @param mixed   $entity       Entity to delete
+     * @param string  $redirectPath Redirect path
      *
      * @return RedirectResponse Redirect response
      *
@@ -165,7 +165,7 @@ class ShippingRangeController extends AbstractAdminController
     public function deleteAction(
         Request $request,
         $entity,
-        $redirectUrl = null
+        $redirectPath = null
     ) {
         /**
          * @var ShippingRangeInterface $entity

--- a/src/Elcodi/Admin/UserBundle/Controller/AdminUserController.php
+++ b/src/Elcodi/Admin/UserBundle/Controller/AdminUserController.php
@@ -238,9 +238,9 @@ class AdminUserController extends AbstractAdminController
     /**
      * Delete entity
      *
-     * @param Request $request     Request
-     * @param mixed   $entity      Entity to delete
-     * @param string  $redirectUrl Redirect url
+     * @param Request $request      Request
+     * @param mixed   $entity       Entity to delete
+     * @param string  $redirectPath Redirect path
      *
      * @return RedirectResponse Redirect response
      *
@@ -260,7 +260,7 @@ class AdminUserController extends AbstractAdminController
     public function deleteAction(
         Request $request,
         $entity,
-        $redirectUrl = null
+        $redirectPath = null
     ) {
         if ($this->isSameUser($entity)) {
             $this->denyWithMessage(

--- a/src/Elcodi/Admin/UserBundle/Controller/CustomerController.php
+++ b/src/Elcodi/Admin/UserBundle/Controller/CustomerController.php
@@ -239,9 +239,9 @@ class CustomerController extends AbstractAdminController
     /**
      * Delete entity
      *
-     * @param Request $request     Request
-     * @param mixed   $entity      Entity to delete
-     * @param string  $redirectUrl Redirect url
+     * @param Request $request      Request
+     * @param mixed   $entity       Entity to delete
+     * @param string  $redirectPath Redirect path
      *
      * @return RedirectResponse Redirect response
      *
@@ -261,7 +261,7 @@ class CustomerController extends AbstractAdminController
     public function deleteAction(
         Request $request,
         $entity,
-        $redirectUrl = null
+        $redirectPath = null
     ) {
         return parent::deleteAction(
             $request,


### PR DESCRIPTION
When a image is removed on a product you get redirected to the product page.
The app is ready to replicate the same behavior on other similar pages.