### PR TITLE
introduce minimum money validator

### DIFF
--- a/src/Elcodi/Admin/CoreBundle/Resources/translations/messages.en.yml
+++ b/src/Elcodi/Admin/CoreBundle/Resources/translations/messages.en.yml
@@ -585,6 +585,7 @@ admin:
         error:
             no_category: Warning! This product has no associated category
             no_manufacturer: Warning! This product has no associated manufacturer
+            price_negative: Warning! The price cannot be negative
         tag:
             in_home: Home
             has_variants: Has variants

--- a/src/Elcodi/Admin/ProductBundle/DependencyInjection/AdminProductExtension.php
+++ b/src/Elcodi/Admin/ProductBundle/DependencyInjection/AdminProductExtension.php
@@ -61,6 +61,7 @@ class AdminProductExtension extends AbstractExtension
             'formTypes',
             'eventListeners',
             'services',
+            'validator',
         ];
     }
 

--- a/src/Elcodi/Admin/ProductBundle/Form/Type/ProductType.php
+++ b/src/Elcodi/Admin/ProductBundle/Form/Type/ProductType.php
@@ -21,6 +21,7 @@ use Symfony\Component\Form\AbstractType;
 use Symfony\Component\Form\FormBuilderInterface;
 use Symfony\Component\OptionsResolver\OptionsResolverInterface;
 
+use Elcodi\Admin\ProductBundle\Validation\MinimumMoney;
 use Elcodi\Component\Core\Factory\Traits\FactoryTrait;
 use Elcodi\Component\EntityTranslator\EventListener\Traits\EntityTranslatableFormTrait;
 
@@ -116,9 +117,19 @@ class ProductType extends AbstractType
             ])
             ->add('price', 'money_object', [
                 'required' => true,
+                'constraints' => [
+                    new MinimumMoney([
+                        'value' => 0
+                    ]),
+                ],
             ])
             ->add('reducedPrice', 'money_object', [
                 'required' => false,
+                'constraints' => [
+                    new MinimumMoney([
+                        'value' => 0
+                    ]),
+                ],
             ])
             ->add('imagesSort', 'text', [
                 'required' => false,

--- a/src/Elcodi/Admin/ProductBundle/Form/Type/VariantType.php
+++ b/src/Elcodi/Admin/ProductBundle/Form/Type/VariantType.php
@@ -21,6 +21,7 @@ use Symfony\Component\Form\AbstractType;
 use Symfony\Component\Form\FormBuilderInterface;
 use Symfony\Component\OptionsResolver\OptionsResolverInterface;
 
+use Elcodi\Admin\ProductBundle\Validation\MinimumMoney;
 use Elcodi\Component\Attribute\Repository\ValueRepository;
 use Elcodi\Component\Core\Factory\Traits\FactoryTrait;
 
@@ -113,9 +114,19 @@ class VariantType extends AbstractType
             ])
             ->add('price', 'money_object', [
                 'required' => false,
+                'constraints' => [
+                    new MinimumMoney([
+                        'value' => 0
+                    ]),
+                ],
             ])
             ->add('reducedPrice', 'money_object', [
                 'required' => false,
+                'constraints' => [
+                    new MinimumMoney([
+                        'value' => 0
+                    ]),
+                ],
             ])
             ->add('enabled', 'checkbox', [
                 'required' => false,

--- a/src/Elcodi/Admin/ProductBundle/Resources/config/validator.yml
+++ b/src/Elcodi/Admin/ProductBundle/Resources/config/validator.yml
@@ -1,0 +1,9 @@
+services:
+
+    #
+    # Constraints
+    #
+    elcodi.validator.minimum_money:
+        class: Elcodi\Admin\ProductBundle\Validation\MinimumMoneyValidator
+        tags:
+            - { name: validator.constraint_validator, alias: minimum_money }

--- a/src/Elcodi/Admin/ProductBundle/Resources/views/Product/edit.html.twig
+++ b/src/Elcodi/Admin/ProductBundle/Resources/views/Product/edit.html.twig
@@ -53,6 +53,10 @@
             <p class="msg-warning">{{ 'admin.product.error.no_manufacturer'|trans }}</p>
         {% endif %}
 
+        {% if product.price.amount < 0 %}
+            <p class="msg-warning">{{ 'admin.product.error.price_negative'|trans }}</p>
+        {% endif %}
+
         {{ render(url('admin_product_edit_component', { id: product.id })) }}
     {% else %}
         {{ render(url('admin_product_new_component')) }}

--- a/src/Elcodi/Admin/ProductBundle/Validation/MinimumMoney.php
+++ b/src/Elcodi/Admin/ProductBundle/Validation/MinimumMoney.php
@@ -1,0 +1,69 @@
+<?php
+
+/*
+ * This file is part of the Elcodi package.
+ *
+ * Copyright (c) 2014-2015 Elcodi.com
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ *
+ * Feel free to edit as you please, and have fun.
+ *
+ * @author Marc Morera <yuhu@mmoreram.com>
+ * @author Aldo Chiecchia <zimage@tiscali.it>
+ * @author Elcodi Team <tech@elcodi.com>
+ */
+
+namespace Elcodi\Admin\ProductBundle\Validation;
+
+use Elcodi\Component\Currency\Entity\Money;
+use Symfony\Component\Validator\Constraint;
+use Symfony\Component\Validator\Exception\ConstraintDefinitionException;
+
+/**
+ * Class MinimumMoney
+ */
+class MinimumMoney extends Constraint
+{
+    /**
+     * @var string
+     *
+     * Constraint message
+     */
+    public $message = 'This value should be greater than or equal to {{ compared_value }}.';
+
+    /**
+     * Value to be validated.
+     *
+     * @var Money
+     */
+    public $value;
+
+    /**
+     * Builds a new class.
+     *
+     * @param array $options
+     */
+    public function __construct($options = null)
+    {
+        if (is_array($options) && !isset($options['value'])) {
+            throw new ConstraintDefinitionException(sprintf(
+                'The %s constraint requires the "value" option to be set.',
+                get_class($this)
+            ));
+        }
+
+        parent::__construct($options);
+    }
+
+    /**
+     * Returns default option.
+     *
+     * @return string
+     */
+    public function getDefaultOption()
+    {
+        return 'value';
+    }
+}

--- a/src/Elcodi/Admin/ProductBundle/Validation/MinimumMoneyValidator.php
+++ b/src/Elcodi/Admin/ProductBundle/Validation/MinimumMoneyValidator.php
@@ -1,0 +1,58 @@
+<?php
+
+/*
+ * This file is part of the Elcodi package.
+ *
+ * Copyright (c) 2014-2015 Elcodi.com
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ *
+ * Feel free to edit as you please, and have fun.
+ *
+ * @author Marc Morera <yuhu@mmoreram.com>
+ * @author Aldo Chiecchia <zimage@tiscali.it>
+ * @author Elcodi Team <tech@elcodi.com>
+ */
+
+namespace Elcodi\Admin\ProductBundle\Validation;
+
+use Symfony\Component\Validator\Constraint;
+use Symfony\Component\Validator\ConstraintValidator;
+use Symfony\Component\Validator\Exception\UnexpectedTypeException;
+
+use Elcodi\Component\Currency\Entity\Money;
+
+/**
+ * Class MinimumMoneyValidator
+ */
+class MinimumMoneyValidator extends ConstraintValidator
+{
+    /**
+     * Validates the value to be greater or equal than the constraint value.
+     *
+     * @param Money      $value
+     * @param Constraint $constraint
+     */
+    public function validate($value, Constraint $constraint)
+    {
+        if (null === $value) {
+            return;
+        }
+
+        if (!($value instanceof Money)) {
+            throw new UnexpectedTypeException($value, 'Elcodi\Component\Currency\Entity\Money');
+        }
+
+        $minimumMoney = Money::create($constraint->value, $value->getCurrency());
+
+        if ($value->isLessThan($minimumMoney)) {
+            $this->context
+                ->buildViolation($constraint->message)
+                ->setParameter('{{ value }}', $this->formatValue($value, self::OBJECT_TO_STRING))
+                ->setParameter('{{ compared_value }}', $this->formatValue($minimumMoney, self::OBJECT_TO_STRING))
+                ->setParameter('{{ compared_value_type }}', $this->formatTypeOf($minimumMoney))
+                ->addViolation();
+        }
+    }
+}


### PR DESCRIPTION
                   
|Q            |A  |
|---          |---|
|Fixed Tickets| #219   |

The MinimumMoney constraint is located in bamboo because for now I don't think this is applicable to every price we want to set. Sometimes we can have debts that can be signaled as such, so this is good here. After it matures into more validators then we can move them in bulk to elcodi/elcodi.

