### PR TITLE
readd database_path for things to work

### DIFF
--- a/app/config/parameters.yml.dist
+++ b/app/config/parameters.yml.dist
@@ -9,6 +9,7 @@ parameters:
     database_name: bamboo
     database_user: root
     database_password: root
+    database_path: false
 
     # Mailer
     mailer_transport: smtp


### PR DESCRIPTION
| Q | A |
| --- | --- |
| Fixed Tickets | not reported |

blocking serious error when running composer install on the default project. The parameter database_patah needs to be set and then overridden on tests with the right value which is already happening on cparameters_test.yml. However initially it has to be set to false so that the command for fixtures can fallback correctly to the default original command. If this is not set then the service definition is invalid because the parameter actually does not exist at all.
