### PR TITLE
adding admin routes from the rules bundle

### DIFF
--- a/app/config/routing/routing_admin.yml
+++ b/app/config/routing/routing_admin.yml
@@ -55,6 +55,9 @@ admin_geo:
 admin_languages:
     resource: "@AdminLanguageBundle/Resources/config/routing.yml"
 
+admin_rule:
+    resource: "@AdminRuleBundle/Resources/config/routing.yml"
+
 admin_login_check:
     path:  /login_check
 


### PR DESCRIPTION
                     
|Q            |A    |
|---          |---  |
|Fixed Tickets|none|
                     

There are admin controllers for rules but they were not required from routing_admin.yml