### PR TITLE
Fix default language namespace in configuration

### DIFF
--- a/app/config/common/configuration.yml
+++ b/app/config/common/configuration.yml
@@ -105,7 +105,7 @@ elcodi_configuration:
         store_default_language:
             key: default_language
             name: Default language
-            namespace: default_language
+            namespace: store
             type: string
 
         #


### PR DESCRIPTION
In fact, to avoid problems, we may want to setup configuration keys like this:
```yaml
store_default_language:
    namespace: store
    key: default_language
    type: string
```