### PR TITLE
Fix mink dependency

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,5 +1,8 @@
 language: php
 
+env:
+    - COMPOSER_OPTIONS="install --prefer-source"
+
 php:
     - 5.4
     - 5.5
@@ -12,6 +15,9 @@ matrix:
     allow_failures:
         - php: 7.0
         - php: hhvm
+    include:
+        - php: 5.4
+          env: COMPOSER_OPTIONS="update --prefer-lowest"
 
 before_install:
     - sh -c "echo 'extension = redis.so' >> ~/.phpenv/versions/$(phpenv version-name)/etc/php.ini"
@@ -20,7 +26,7 @@ before_install:
     - sh -c "sudo mount -t tmpfs -o size=512M tmpfs vendor"
 
 install:
-    - composer install --prefer-source --no-interaction
+    - composer ${COMPOSER_OPTIONS} --no-interaction
 
 before_script:
     - sh -c "sudo mkdir /tmp/Bamboo"

--- a/composer.json
+++ b/composer.json
@@ -115,7 +115,7 @@
         "doctrine/data-fixtures": "~1.0",
         "behat/behat": "~3.0",
         "behat/symfony2-extension": "~2.0",
-        "behat/mink-extension": "~2.0",
+        "behat/mink-extension": "~2.0, >=2.0.1",
         "behat/mink-browserkit-driver": "~1.2",
         "behat/mink": "~1.6",
         "phpunit/phpunit": "4.5.0",


### PR DESCRIPTION
Behat tests are failing with lowest dependencies from `composer`.
This adds travis settings to test lowest dependencies and fixes behat.