### PR TITLE
remove unneeded require because AppKernel is already loaded via bootstrap

### DIFF
--- a/app/console
+++ b/app/console
@@ -22,7 +22,6 @@
 set_time_limit(0);
 
 require_once __DIR__.'/bootstrap.php.cache';
-require_once __DIR__.'/AppKernel.php';
 
 use Symfony\Bundle\FrameworkBundle\Console\Application;
 use Symfony\Component\Console\Input\ArgvInput;


### PR DESCRIPTION
                   
|Q            |A  |
|---          |---|
|Fixed Tickets|-  |
                   

-