### PR TITLE
Make Visithor a really optional dependency

### DIFF
--- a/app/AppKernel.php
+++ b/app/AppKernel.php
@@ -169,7 +169,9 @@ class AppKernel extends Kernel
             $bundles[] = new Elcodi\Bundle\FixturesBoosterBundle\ElcodiFixturesBoosterBundle();
             $bundles[] = new Symfony\Bundle\WebProfilerBundle\WebProfilerBundle();
             $bundles[] = new Sensio\Bundle\DistributionBundle\SensioDistributionBundle();
+        }
 
+        if (class_exists('Visithor\Bundle\VisithorBundle')) {
             $bundles[] = new Visithor\Bundle\VisithorBundle();
             $bundles[] = new Elcodi\Common\VisithorBridgeBundle\VisithorBridgeBundle();
         }


### PR DESCRIPTION
As Visithor may or may not be installed (as it is a dev-dependency) but you may want to launch it in any environment, I'd rather check for existance before adding to the kernel.