### PR TITLE
Disable social buttons on admin page

### DIFF
--- a/src/Elcodi/Plugin/FacebookBundle/Resources/config/templating.yml
+++ b/src/Elcodi/Plugin/FacebookBundle/Resources/config/templating.yml
@@ -22,7 +22,6 @@ services:
             - [setPlugin, [@=elcodi_plugin("Elcodi\\Plugin\\FacebookBundle")]]
         tags:
             - { name: kernel.event_listener, event: store.product_pin_top, method: renderShareProduct }
-            - { name: kernel.event_listener, event: admin.product_top, method: renderShareProduct }
             - { name: kernel.event_listener, event: store.order_thanks, method: renderShareOrder }
 
     elcodi_plugin.facebook.follow_renderer:

--- a/src/Elcodi/Plugin/TwitterBundle/Resources/config/templating.yml
+++ b/src/Elcodi/Plugin/TwitterBundle/Resources/config/templating.yml
@@ -22,7 +22,6 @@ services:
             - [setPlugin, [@=elcodi_plugin("Elcodi\\Plugin\\TwitterBundle")]]
         tags:
             - { name: kernel.event_listener, event: store.product_pin_top, method: renderShareProduct }
-            - { name: kernel.event_listener, event: admin.product_top, method: renderShareProduct }
             - { name: kernel.event_listener, event: store.order_thanks, method: renderShareOrder }
 
     elcodi_plugin.twitter.follow_renderer:


### PR DESCRIPTION
For two reasons:
* From a UX point of view has no sense
* Creates a security bug whan opening modal windows (new category, new manufactureer)