### PR TITLE
Fix redirection after delete

### DIFF
--- a/src/Elcodi/Admin/AttributeBundle/Controller/AttributeController.php
+++ b/src/Elcodi/Admin/AttributeBundle/Controller/AttributeController.php
@@ -263,7 +263,7 @@ class AttributeController extends AbstractAdminController
         return parent::deleteAction(
             $request,
             $entity,
-            'admin_attribute_list'
+            $this->generateUrl('admin_attribute_list')
         );
     }
 

--- a/src/Elcodi/Admin/BannerBundle/Controller/BannerController.php
+++ b/src/Elcodi/Admin/BannerBundle/Controller/BannerController.php
@@ -535,7 +535,7 @@ class BannerController extends AbstractAdminController
         return parent::deleteAction(
             $request,
             $entity,
-            'admin_banner_list'
+            $this->generateUrl('admin_banner_list')
         );
     }
 }

--- a/src/Elcodi/Admin/BannerBundle/Controller/BannerZoneController.php
+++ b/src/Elcodi/Admin/BannerBundle/Controller/BannerZoneController.php
@@ -516,7 +516,7 @@ class BannerZoneController extends AbstractAdminController
         return parent::deleteAction(
             $request,
             $entity,
-            'admin_banner_zone_list'
+            $this->generateUrl('admin_banner_zone_list')
         );
     }
 }

--- a/src/Elcodi/Admin/CouponBundle/Controller/CouponController.php
+++ b/src/Elcodi/Admin/CouponBundle/Controller/CouponController.php
@@ -252,7 +252,7 @@ class CouponController extends AbstractAdminController
         return parent::deleteAction(
             $request,
             $entity,
-            'admin_coupon_list'
+            $this->generateUrl('admin_coupon_list')
         );
     }
 }

--- a/src/Elcodi/Admin/NewsletterBundle/Controller/NewsletterSubscriptionController.php
+++ b/src/Elcodi/Admin/NewsletterBundle/Controller/NewsletterSubscriptionController.php
@@ -344,7 +344,7 @@ class NewsletterSubscriptionController extends AbstractAdminController
         return parent::deleteAction(
             $request,
             $entity,
-            'admin_newsletter_subscription_list'
+            $this->generateUrl('admin_newsletter_subscription_list')
         );
     }
 }

--- a/src/Elcodi/Admin/PageBundle/Controller/BlogPostController.php
+++ b/src/Elcodi/Admin/PageBundle/Controller/BlogPostController.php
@@ -195,7 +195,7 @@ class BlogPostController extends AbstractAdminController
         return parent::deleteAction(
             $request,
             $entity,
-            'admin_blog_post_list'
+            $this->generateUrl('admin_blog_post_list')
         );
     }
 }

--- a/src/Elcodi/Admin/PageBundle/Controller/PageController.php
+++ b/src/Elcodi/Admin/PageBundle/Controller/PageController.php
@@ -279,7 +279,7 @@ class PageController extends AbstractAdminController
         return parent::deleteAction(
             $request,
             $entity,
-            'admin_page_list'
+            $this->generateUrl('admin_page_list')
         );
     }
 

--- a/src/Elcodi/Admin/ProductBundle/Controller/CategoryController.php
+++ b/src/Elcodi/Admin/ProductBundle/Controller/CategoryController.php
@@ -246,7 +246,7 @@ class CategoryController extends AbstractAdminController
         return parent::deleteAction(
             $request,
             $entity,
-            'admin_category_list'
+            $this->generateUrl('admin_category_list')
         );
     }
 }

--- a/src/Elcodi/Admin/ProductBundle/Controller/ManufacturerController.php
+++ b/src/Elcodi/Admin/ProductBundle/Controller/ManufacturerController.php
@@ -277,7 +277,7 @@ class ManufacturerController extends AbstractAdminController
         return parent::deleteAction(
             $request,
             $entity,
-            'admin_manufacturer_list'
+            $this->generateUrl('admin_manufacturer_list')
         );
     }
 }

--- a/src/Elcodi/Admin/ProductBundle/Controller/ProductController.php
+++ b/src/Elcodi/Admin/ProductBundle/Controller/ProductController.php
@@ -276,7 +276,7 @@ class ProductController extends AbstractAdminController
         return parent::deleteAction(
             $request,
             $entity,
-            'admin_product_list'
+            $this->generateUrl('admin_product_list')
         );
     }
 }

--- a/src/Elcodi/Admin/ProductBundle/Controller/VariantController.php
+++ b/src/Elcodi/Admin/ProductBundle/Controller/VariantController.php
@@ -336,8 +336,7 @@ class VariantController extends AbstractAdminController
 
         return parent::deleteAction(
             $request,
-            $variant,
-            null
+            $variant
         );
     }
 

--- a/src/Elcodi/Admin/RuleBundle/Controller/RuleController.php
+++ b/src/Elcodi/Admin/RuleBundle/Controller/RuleController.php
@@ -534,7 +534,7 @@ class RuleController extends AbstractAdminController
         return parent::deleteAction(
             $request,
             $entity,
-            'admin_rule_list'
+            $this->generateUrl('admin_rule_list')
         );
     }
 }

--- a/src/Elcodi/Admin/ShippingBundle/Controller/CarrierController.php
+++ b/src/Elcodi/Admin/ShippingBundle/Controller/CarrierController.php
@@ -180,7 +180,7 @@ class CarrierController extends AbstractAdminController
         return parent::deleteAction(
             $request,
             $entity,
-            'admin_carrier_list'
+            $this->generateUrl('admin_carrier_list')
         );
     }
 }

--- a/src/Elcodi/Admin/ShippingBundle/Controller/ShippingRangeController.php
+++ b/src/Elcodi/Admin/ShippingBundle/Controller/ShippingRangeController.php
@@ -177,12 +177,9 @@ class ShippingRangeController extends AbstractAdminController
         parent::deleteAction(
             $request,
             $entity,
-            null
-        );
-
-        return $this
-            ->redirectToRoute('admin_carrier_edit', [
+            $this->generateUrl('admin_carrier_edit', [
                 'id' => $carrierId,
-            ]);
+            ])
+        );
     }
 }

--- a/src/Elcodi/Admin/UserBundle/Controller/AdminUserController.php
+++ b/src/Elcodi/Admin/UserBundle/Controller/AdminUserController.php
@@ -271,7 +271,7 @@ class AdminUserController extends AbstractAdminController
         return parent::deleteAction(
             $request,
             $entity,
-            'admin_admin_user_list'
+            $this->generateUrl('admin_admin_user_list')
         );
     }
 

--- a/src/Elcodi/Admin/UserBundle/Controller/CustomerController.php
+++ b/src/Elcodi/Admin/UserBundle/Controller/CustomerController.php
@@ -266,7 +266,7 @@ class CustomerController extends AbstractAdminController
         return parent::deleteAction(
             $request,
             $entity,
-            'admin_customer_list'
+            $this->generateUrl('admin_customer_list')
         );
     }
 }


### PR DESCRIPTION
After removing any element, redirection is not done right because it's working with full paths but route names are passed. This PR generates routes before trying to remove.