### PR TITLE
coupon type fix

### DIFF
--- a/src/Elcodi/Admin/CouponBundle/Form/Type/CouponType.php
+++ b/src/Elcodi/Admin/CouponBundle/Form/Type/CouponType.php
@@ -82,7 +82,7 @@ class CouponType extends AbstractType
                 'required' => true,
             ])
             ->add('name', 'text', [
-                'required' => false,
+                'required' => true,
             ])
             ->add('type', 'choice', [
                 'required' => true,


### PR DESCRIPTION
changed name field to required in order to avoid doctrine exception