### PR TITLE
Hide plugins marked as not visible

### DIFF
--- a/src/Elcodi/Admin/PluginBundle/Resources/views/Plugin/list.html.twig
+++ b/src/Elcodi/Admin/PluginBundle/Resources/views/Plugin/list.html.twig
@@ -20,7 +20,7 @@
 {% block content %}
 
     <form class="form-grid form-grid-has-settings form-save-on-edit" data-fc-modules="form-save-on-edit">
-        {% for plugin in plugins %}
+        {% for plugin in plugins if plugin.getConfigurationValue('visible') %}
             {% set pluginName = plugin.getConfigurationValue('name')|trans %}
             {% set pluginDescription = plugin.getConfigurationValue('description')|trans %}
             {% set iconPath = "/bundles" ~ asset(plugin.getBundleName()|replace({'Bundle': ''})|lower ~ "/images/icon.png") %}


### PR DESCRIPTION
As `visible` defaults to `true` in [PluginConfiguration.php#L54-L56](https://github.com/elcodi/elcodi/blob/master/src/Elcodi/Component/Plugin/Services/PluginConfiguration.php#L54-L56), it can be safely requested with `getConfigurationValue`.