### PR TITLE
Fix jms-i18n setup

### DIFF
--- a/app/config/config.yml
+++ b/app/config/config.yml
@@ -117,13 +117,14 @@ hwi_oauth:
                 sandbox: %bamboo_social_paypal_client_is_sandbox%
 
 jms_i18n_routing:
-    default_locale: %locale%
-    #
-    # This value is not used anymore. Please, take a look at services.yml file
-    # in this folder. All references to this parameter are overridden
-    #
-    locales: [en]
     strategy: prefix_except_default
+    #
+    # Locale values exist here only for validation purposes.
+    # All references to this configuration are overriden.
+    # See common/services.yml file in this folder for more insight.
+    #
+    default_locale: en
+    locales: [en]
 
 #
 # Elcodi related configuration


### PR DESCRIPTION
Setup with `default_locale: %locale%` breaks validation when it's different from `en`.
Hardcoding the value works well (which is later overriden in `common/services.yml`)
Also edited and moved the comment explaining this.