### PR TITLE
Different menu entries from plugin type

### DIFF
--- a/features/admin/menu.feature
+++ b/features/admin/menu.feature
@@ -25,10 +25,10 @@ Feature: Admin menus
     And the page contains a "admin.settings.section.store.title" test attribute
     And the page contains a "admin.settings.section.address.title" test attribute
     And the page contains a "admin.settings.section.corporate.title" test attribute
-    And the page contains a "admin.carrier.plural" test attribute
     And the page contains a "admin.currency.plural" test attribute
     And the page contains a "admin.language.plural" test attribute
-    And the page contains a "admin.settings.section.payment.title" test attribute
-    And the page contains a "admin.social.single" test attribute
+    And the page contains a "plugin_type.payment" test attribute
+    And the page contains a "plugin_type.shipping" test attribute
+    And the page contains a "plugin_type.social" test attribute
     And the page contains a "menu-profile" test attribute
     And the page contains a "menu-logout" test attribute

--- a/src/Elcodi/Admin/CoreBundle/Resources/translations/messages.ca.yml
+++ b/src/Elcodi/Admin/CoreBundle/Resources/translations/messages.ca.yml
@@ -998,3 +998,9 @@ ui:
         success: Borrat correctament
     editor:
         help: Selecciona el text per a veure les opcions de format
+
+plugin_type:
+    app: Aplicacions
+    payment: Mètodes de pagament
+    shipping: Transportistes
+    social: Social

--- a/src/Elcodi/Admin/CoreBundle/Resources/translations/messages.en.yml
+++ b/src/Elcodi/Admin/CoreBundle/Resources/translations/messages.en.yml
@@ -1004,3 +1004,9 @@ ui:
         success: Correctly deleted
     editor:
         help: Select some text to get some format options
+
+plugin_type:
+    app: Apps
+    payment: Payment methods
+    shipping: Shipping methods
+    social: Social

--- a/src/Elcodi/Admin/CoreBundle/Resources/translations/messages.es.yml
+++ b/src/Elcodi/Admin/CoreBundle/Resources/translations/messages.es.yml
@@ -1001,3 +1001,9 @@ ui:
         success: Borrado correctamente
     editor:
         help: Selecciona el texto para ver las opciones de formato
+
+plugin_type:
+    app: Aplicaciones
+    payment: Métodos de pago
+    shipping: Transportistas
+    social: Social

--- a/src/Elcodi/Admin/CoreBundle/Resources/views/Navs/side_elements.html.twig
+++ b/src/Elcodi/Admin/CoreBundle/Resources/views/Navs/side_elements.html.twig
@@ -10,7 +10,11 @@
 {% macro showNode(node, route) %}
     <li class="{% if node.isActive(route) %}active{% endif %}{% if node.subnodes|length %}parent{% endif %}" data-test="{{ node.name }}">
     {% if node.subnodes|length == 0 %}
-        <a href="{{ generate_url(node.url) }}">
+        {% set node_url = node.url is iterable
+            ? url(node.url[0], node.url[1])
+            : url(node.url)
+        %}
+        <a href="{{ node_url }}">
     {% else %}
         <a href="#{{ node.name|md5 }}" data-fc-modules="toggle">
             <i class="icon-caret-down fl-r"></i>
@@ -30,7 +34,11 @@
                 <ul id="{{ node.name|md5 }}" {% if not node.isExpanded(route) %}class="hidden"{% endif %}>
             {% endif %}
             <li {% if subnode.isActive(route) %}class="active"{% endif %} data-test="{{ subnode.name }}">
-                <a href="{{ generate_url(subnode.url) }}" class="pl-l"><i class="icon-angle-right"></i> {{ subnode.name|trans }}</a>
+                {% set subnode_url = subnode.url is iterable
+                    ? url(subnode.url[0], subnode.url[1])
+                    : url(subnode.url)
+                %}
+                <a href="{{ subnode_url }}" class="pl-l"><i class="icon-angle-right"></i> {{ subnode.name|trans }}</a>
             </li>
             {% if loop.last %}
                 </ul>

--- a/src/Elcodi/Admin/CoreBundle/Resources/views/Navs/side_elements_mobile.html.twig
+++ b/src/Elcodi/Admin/CoreBundle/Resources/views/Navs/side_elements_mobile.html.twig
@@ -9,8 +9,12 @@
 
 {% macro showNode(node, route) %}
     <li class="{% if node.isActive(route) %}active{% endif %}{% if node.subnodes|length %}parent{% endif %}" data-test="{{ node.name }}">
-    {% if generate_url(node.url) != '' %}
-        <a href="{{ generate_url(node.url) }}">
+    {% if node.subnodes|length == 0 %}
+        {% set node_url = node.url is iterable
+            ? url(node.url[0], node.url[1])
+            : url(node.url)
+        %}
+        <a href="{{ node_url }}">
     {% else %}
         <a href="#{{ node.name|md5 }}" data-fc-modules="toggle">
             <i class="icon-caret-down fl-r"></i>
@@ -30,7 +34,11 @@
                 <ul id="{{ node.name|md5 }}" {% if not node.isExpanded(route) %}class="hidden"{% endif %}>
             {% endif %}
             <li {% if subnode.isActive(route) %}class="active"{% endif %} data-test="{{ subnode.name }}">
-                <a href="{{ generate_url(subnode.url) }}" class="pl-l"><i class="icon-angle-right"></i> {{ subnode.name|trans }}</a>
+                {% set subnode_url = subnode.url is iterable
+                    ? url(subnode.url[0], subnode.url[1])
+                    : url(subnode.url)
+                %}
+                <a href="{{ subnode_url }}" class="pl-l"><i class="icon-angle-right"></i> {{ subnode.name|trans }}</a>
             </li>
             {% if loop.last %}
                 </ul>

--- a/src/Elcodi/Admin/PaymentBundle/Builder/MenuBuilder.php
+++ b/src/Elcodi/Admin/PaymentBundle/Builder/MenuBuilder.php
@@ -38,7 +38,7 @@ class MenuBuilder extends AbstractMenuBuilder implements MenuBuilderInterface
                 $this
                     ->menuNodeFactory
                     ->create()
-                    ->setName('admin.settings.section.payment.title')
+                    ->setName('plugin_type.payment')
                     ->setTag('settings')
                     ->setCode('credit-card')
                     ->setPriority(31)

--- a/src/Elcodi/Admin/PluginBundle/Builder/MenuBuilder.php
+++ b/src/Elcodi/Admin/PluginBundle/Builder/MenuBuilder.php
@@ -59,7 +59,7 @@ class MenuBuilder extends AbstractMenuBuilder implements MenuBuilderInterface
                 $this
                     ->menuNodeFactory
                     ->create()
-                    ->setName('admin.social.single')
+                    ->setName('plugin_type.social')
                     ->setCode('share-alt')
                     ->setTag('settings')
                     ->setPriority(32)

--- a/src/Elcodi/Admin/PluginBundle/Builder/PluginCategoryMenuBuilder.php
+++ b/src/Elcodi/Admin/PluginBundle/Builder/PluginCategoryMenuBuilder.php
@@ -1,0 +1,75 @@
+<?php
+
+/*
+ * This file is part of the Elcodi package.
+ *
+ * Copyright (c) 2014-2015 Elcodi.com
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ *
+ * Feel free to edit as you please, and have fun.
+ *
+ * @author Marc Morera <yuhu@mmoreram.com>
+ * @author Aldo Chiecchia <zimage@tiscali.it>
+ * @author Elcodi Team <tech@elcodi.com>
+ */
+
+namespace Elcodi\Admin\PluginBundle\Builder;
+
+use Elcodi\Component\Menu\Builder\Abstracts\AbstractMenuBuilder;
+use Elcodi\Component\Menu\Builder\Interfaces\MenuBuilderInterface;
+use Elcodi\Component\Menu\Entity\Menu\Interfaces\MenuInterface;
+
+/**
+ * Class PluginCategoryMenuBuilder
+ */
+class PluginCategoryMenuBuilder extends AbstractMenuBuilder implements MenuBuilderInterface
+{
+    /**
+     * Build the menu
+     *
+     * @param MenuInterface $menu Menu
+     */
+    public function build(MenuInterface $menu)
+    {
+        $plugin = $menu->findSubnodeByName('plugin_type.social');
+        if ($plugin) {
+            $plugin
+                ->addSubnode(
+                    $this
+                        ->menuNodeFactory
+                        ->create()
+                        ->setName('admin.plugin.social_store')
+                        ->setUrl('admin_plugin_social_list')
+                        ->setPriority(9999)
+                );
+        }
+
+        $plugin = $menu->findSubnodeByName('plugin_type.payment');
+        if ($plugin) {
+            $plugin
+                ->addSubnode(
+                    $this
+                        ->menuNodeFactory
+                        ->create()
+                        ->setName('admin.plugin.payment_store')
+                        ->setUrl('admin_plugin_payment_list')
+                        ->setPriority(9999)
+                );
+        }
+
+        $plugin = $menu->findSubnodeByName('plugin_type.shipping');
+        if ($plugin) {
+            $plugin
+                ->addSubnode(
+                    $this
+                        ->menuNodeFactory
+                        ->create()
+                        ->setName('admin.plugin.shipping_store')
+                        ->setUrl('admin_plugin_shipping_list')
+                        ->setPriority(9999)
+                );
+        }
+    }
+}

--- a/src/Elcodi/Admin/PluginBundle/Builder/PluginCategoryMenuBuilder.php
+++ b/src/Elcodi/Admin/PluginBundle/Builder/PluginCategoryMenuBuilder.php
@@ -33,43 +33,49 @@ class PluginCategoryMenuBuilder extends AbstractMenuBuilder implements MenuBuild
      */
     public function build(MenuInterface $menu)
     {
-        $plugin = $menu->findSubnodeByName('plugin_type.social');
-        if ($plugin) {
-            $plugin
-                ->addSubnode(
-                    $this
-                        ->menuNodeFactory
-                        ->create()
-                        ->setName('admin.plugin.social_store')
-                        ->setUrl('admin_plugin_social_list')
-                        ->setPriority(9999)
-                );
-        }
+        $menu
+            ->findSubnodeByName('plugin_type.social')
+            ->addSubnode(
+                $this
+                    ->menuNodeFactory
+                    ->create()
+                    ->setName('admin.plugin.social_store')
+                    ->setUrl([
+                        'admin_plugin_categorized_list', [
+                            'category' => 'social',
+                        ],
+                    ])
+                    ->setPriority(9999)
+            );
 
-        $plugin = $menu->findSubnodeByName('plugin_type.payment');
-        if ($plugin) {
-            $plugin
-                ->addSubnode(
-                    $this
-                        ->menuNodeFactory
-                        ->create()
-                        ->setName('admin.plugin.payment_store')
-                        ->setUrl('admin_plugin_payment_list')
-                        ->setPriority(9999)
-                );
-        }
+        $menu
+            ->findSubnodeByName('plugin_type.payment')
+            ->addSubnode(
+                $this
+                    ->menuNodeFactory
+                    ->create()
+                    ->setName('admin.plugin.payment_store')
+                    ->setUrl([
+                        'admin_plugin_categorized_list', [
+                            'category' => 'payment',
+                        ],
+                    ])
+                    ->setPriority(9999)
+            );
 
-        $plugin = $menu->findSubnodeByName('plugin_type.shipping');
-        if ($plugin) {
-            $plugin
-                ->addSubnode(
-                    $this
-                        ->menuNodeFactory
-                        ->create()
-                        ->setName('admin.plugin.shipping_store')
-                        ->setUrl('admin_plugin_shipping_list')
-                        ->setPriority(9999)
-                );
-        }
+        $menu
+            ->findSubnodeByName('plugin_type.shipping')
+            ->addSubnode(
+                $this
+                    ->menuNodeFactory
+                    ->create()
+                    ->setName('admin.plugin.shipping_store')
+                    ->setUrl([
+                        'admin_plugin_categorized_list', [
+                            'category' => 'shipping',
+                        ],
+                    ])
+                    ->setPriority(9999)
+            );
     }
 }

--- a/src/Elcodi/Admin/PluginBundle/Builder/PluginMenuBuilder.php
+++ b/src/Elcodi/Admin/PluginBundle/Builder/PluginMenuBuilder.php
@@ -17,8 +17,6 @@
 
 namespace Elcodi\Admin\PluginBundle\Builder;
 
-use Symfony\Component\Routing\Generator\UrlGeneratorInterface;
-
 use Elcodi\Component\Menu\Builder\Interfaces\MenuBuilderInterface;
 use Elcodi\Component\Menu\Entity\Menu\Interfaces\MenuInterface;
 use Elcodi\Component\Menu\Entity\Menu\Interfaces\NodeInterface;
@@ -38,13 +36,6 @@ class PluginMenuBuilder implements MenuBuilderInterface
     protected $menuNodeFactory;
 
     /**
-     * @var UrlGeneratorInterface
-     *
-     * Url generator
-     */
-    protected $urlGenerator;
-
-    /**
      * @var Plugin[]
      *
      * Plugins configuration
@@ -54,17 +45,14 @@ class PluginMenuBuilder implements MenuBuilderInterface
     /**
      * Constructor
      *
-     * @param NodeFactory           $menuNodeFactory Menu node factory
-     * @param UrlGeneratorInterface $urlGenerator    Url generator
-     * @param array                 $enabledPlugins  Enabled Plugins
+     * @param NodeFactory $menuNodeFactory Menu node factory
+     * @param array       $enabledPlugins  Enabled Plugins
      */
     public function __construct(
         NodeFactory $menuNodeFactory,
-        UrlGeneratorInterface $urlGenerator,
         array $enabledPlugins
     ) {
         $this->menuNodeFactory = $menuNodeFactory;
-        $this->urlGenerator = $urlGenerator;
         $this->enabledPlugins = $enabledPlugins;
     }
 
@@ -114,18 +102,16 @@ class PluginMenuBuilder implements MenuBuilderInterface
                 continue;
             }
 
-            $pluginConfigurationRoute = $this
-                ->urlGenerator
-                ->generate('admin_plugin_configure', [
-                    'pluginHash' => $plugin->getHash(),
-                ]);
-
             $node = $this
                 ->menuNodeFactory
                 ->create()
                 ->setName($plugin->getConfigurationValue('name'))
                 ->setCode($plugin->getConfigurationValue('fa_icon'))
-                ->setUrl($pluginConfigurationRoute)
+                ->setUrl([
+                    'admin_plugin_configure', [
+                        'pluginHash' => $plugin->getHash(),
+                    ],
+                ])
                 ->setEnabled(true);
 
             $parentNode->addSubnode($node);

--- a/src/Elcodi/Admin/PluginBundle/Builder/PluginMenuBuilder.php
+++ b/src/Elcodi/Admin/PluginBundle/Builder/PluginMenuBuilder.php
@@ -21,6 +21,7 @@ use Symfony\Component\Routing\Generator\UrlGeneratorInterface;
 
 use Elcodi\Component\Menu\Builder\Interfaces\MenuBuilderInterface;
 use Elcodi\Component\Menu\Entity\Menu\Interfaces\MenuInterface;
+use Elcodi\Component\Menu\Entity\Menu\Interfaces\NodeInterface;
 use Elcodi\Component\Menu\Factory\NodeFactory;
 use Elcodi\Component\Plugin\Entity\Plugin;
 
@@ -78,40 +79,35 @@ class PluginMenuBuilder implements MenuBuilderInterface
 
         $this
             ->buildByPluginCategory(
-                $menu,
+                $menu->findSubnodeByName('plugin_type.payment'),
                 $visiblePlugins,
-                'payment',
-                'admin.settings.section.payment.title'
+                'payment'
             )
             ->buildByPluginCategory(
-                $menu,
+                $menu->findSubnodeByName('plugin_type.shipping'),
                 $visiblePlugins,
-                'shipping',
-                'admin.carrier.plural'
+                'shipping'
             )
             ->buildByPluginCategory(
-                $menu,
+                $menu->findSubnodeByName('plugin_type.social'),
                 $visiblePlugins,
-                'social',
-                'admin.social.single'
+                'social'
             );
     }
 
     /**
      * Build by category and place all menu entries inside a family
      *
-     * @param MenuInterface $menu           Menu
+     * @param NodeInterface $parentNode     Parent menu node
      * @param Plugin[]      $plugins        Plugins
      * @param string        $pluginCategory Plugin category
-     * @param string        $parentName     Parent name
      *
      * @return $this Self object
      */
     private function buildByPluginCategory(
-        MenuInterface $menu,
+        NodeInterface $parentNode,
         array $plugins,
-        $pluginCategory,
-        $parentName
+        $pluginCategory
     ) {
         foreach ($plugins as $plugin) {
             if ($plugin->getCategory() !== $pluginCategory) {
@@ -124,7 +120,7 @@ class PluginMenuBuilder implements MenuBuilderInterface
                     'pluginHash' => $plugin->getHash(),
                 ]);
 
-            $menuNode = $this
+            $node = $this
                 ->menuNodeFactory
                 ->create()
                 ->setName($plugin->getConfigurationValue('name'))
@@ -132,9 +128,7 @@ class PluginMenuBuilder implements MenuBuilderInterface
                 ->setUrl($pluginConfigurationRoute)
                 ->setEnabled(true);
 
-            $menu
-                ->findSubnodeByName($parentName)
-                ->addSubnode($menuNode);
+            $parentNode->addSubnode($node);
         }
 
         return $this;

--- a/src/Elcodi/Admin/PluginBundle/Controller/PluginController.php
+++ b/src/Elcodi/Admin/PluginBundle/Controller/PluginController.php
@@ -49,6 +49,28 @@ class PluginController extends AbstractAdminController
      *      name = "admin_plugin_list",
      *      methods = {"GET"}
      * )
+     *
+     * @Route(
+     *      path = "s/payment",
+     *      name = "admin_plugin_payment_list",
+     *      defaults = { "category": "payment" },
+     *      methods = {"GET"}
+     * )
+     *
+     * @Route(
+     *      path = "s/shipping",
+     *      name = "admin_plugin_shipping_list",
+     *      defaults = { "category": "shipping" },
+     *      methods = {"GET"}
+     * )
+     *
+     * @Route(
+     *      path = "s/social",
+     *      name = "admin_plugin_social_list",
+     *      defaults = { "category": "social" },
+     *      methods = {"GET"}
+     * )
+     *
      * @Template
      */
     public function listAction($category = null)

--- a/src/Elcodi/Admin/PluginBundle/Controller/PluginController.php
+++ b/src/Elcodi/Admin/PluginBundle/Controller/PluginController.php
@@ -45,7 +45,7 @@ class PluginController extends AbstractAdminController
      * @return array Result
      *
      * @Route(
-     *      path = "s/{category}",
+     *      path = "s",
      *      name = "admin_plugin_list",
      *      methods = {"GET"}
      * )

--- a/src/Elcodi/Admin/PluginBundle/Controller/PluginController.php
+++ b/src/Elcodi/Admin/PluginBundle/Controller/PluginController.php
@@ -40,25 +40,34 @@ class PluginController extends AbstractAdminController
     /**
      * List plugins
      *
+     * @param string $category Optional plugin category
+     *
      * @return array Result
      *
      * @Route(
-     *      path = "s",
+     *      path = "s/{category}",
      *      name = "admin_plugin_list",
      *      methods = {"GET"}
      * )
      * @Template
      */
-    public function listAction()
+    public function listAction($category = null)
     {
+        $criteria = [
+            'type' => PluginTypes::TYPE_PLUGIN,
+        ];
+
+        if ($category !== null) {
+            $criteria['category'] = $category;
+        }
+
         $plugins = $this
             ->get('elcodi.repository.plugin')
-            ->findBy([
-                'type' => PluginTypes::TYPE_PLUGIN,
-            ]);
+            ->findBy($criteria, [ 'category' => 'ASC' ]);
 
         return [
             'plugins' => $plugins,
+            'category' => $category,
         ];
     }
 

--- a/src/Elcodi/Admin/PluginBundle/Controller/PluginController.php
+++ b/src/Elcodi/Admin/PluginBundle/Controller/PluginController.php
@@ -51,23 +51,8 @@ class PluginController extends AbstractAdminController
      * )
      *
      * @Route(
-     *      path = "s/payment",
-     *      name = "admin_plugin_payment_list",
-     *      defaults = { "category": "payment" },
-     *      methods = {"GET"}
-     * )
-     *
-     * @Route(
-     *      path = "s/shipping",
-     *      name = "admin_plugin_shipping_list",
-     *      defaults = { "category": "shipping" },
-     *      methods = {"GET"}
-     * )
-     *
-     * @Route(
-     *      path = "s/social",
-     *      name = "admin_plugin_social_list",
-     *      defaults = { "category": "social" },
+     *      path = "s/{category}",
+     *      name = "admin_plugin_categorized_list",
      *      methods = {"GET"}
      * )
      *
@@ -85,7 +70,10 @@ class PluginController extends AbstractAdminController
 
         $plugins = $this
             ->get('elcodi.repository.plugin')
-            ->findBy($criteria, [ 'category' => 'ASC' ]);
+            ->findBy(
+                $criteria,
+                [ 'category' => 'ASC' ]
+            );
 
         return [
             'plugins' => $plugins,

--- a/src/Elcodi/Admin/PluginBundle/DependencyInjection/AdminPluginExtension.php
+++ b/src/Elcodi/Admin/PluginBundle/DependencyInjection/AdminPluginExtension.php
@@ -58,6 +58,8 @@ class AdminPluginExtension extends AbstractExtension
     {
         return [
             'menu',
+            [ 'categoriesMenu', $config['menu']['add_categories'] ],
+            [ 'pluginMenu', $config['menu']['add_plugins'] ],
         ];
     }
 
@@ -69,5 +71,15 @@ class AdminPluginExtension extends AbstractExtension
     public function getAlias()
     {
         return self::EXTENSION_NAME;
+    }
+
+    /**
+     * Return the configuration
+     *
+     * @return Configuration
+     */
+    protected function getConfigurationInstance()
+    {
+        return new Configuration(self::EXTENSION_NAME);
     }
 }

--- a/src/Elcodi/Admin/PluginBundle/DependencyInjection/Configuration.php
+++ b/src/Elcodi/Admin/PluginBundle/DependencyInjection/Configuration.php
@@ -1,0 +1,52 @@
+<?php
+
+/*
+ * This file is part of the Elcodi package.
+ *
+ * Copyright (c) 2014-2015 Elcodi.com
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ *
+ * Feel free to edit as you please, and have fun.
+ *
+ * @author Marc Morera <yuhu@mmoreram.com>
+ * @author Aldo Chiecchia <zimage@tiscali.it>
+ * @author Elcodi Team <tech@elcodi.com>
+ */
+
+namespace Elcodi\Admin\PluginBundle\DependencyInjection;
+
+use Symfony\Component\Config\Definition\Builder\ArrayNodeDefinition;
+
+use Elcodi\Bundle\CoreBundle\DependencyInjection\Abstracts\AbstractConfiguration;
+
+/**
+ * Class Configuration
+ */
+class Configuration extends AbstractConfiguration
+{
+    /**
+     * Configure the root node
+     *
+     * @param ArrayNodeDefinition $rootNode Root node
+     */
+    protected function setupTree(ArrayNodeDefinition $rootNode)
+    {
+        $rootNode
+            ->addDefaultsIfNotSet()
+            ->children()
+                ->arrayNode('menu')
+                    ->addDefaultsIfNotSet()
+                    ->children()
+                        ->booleanNode('add_categories')
+                            ->defaultFalse()
+                        ->end()
+                        ->booleanNode('add_plugins')
+                            ->defaultTrue()
+                        ->end()
+                    ->end()
+                ->end()
+            ->end();
+    }
+}

--- a/src/Elcodi/Admin/PluginBundle/Resources/config/categoriesMenu.yml
+++ b/src/Elcodi/Admin/PluginBundle/Resources/config/categoriesMenu.yml
@@ -8,4 +8,4 @@ services:
         arguments:
             - @elcodi.factory.menu_node
         tags:
-            - { name: menu.builder, menu: admin, priority: 16 }
+            - { name: menu.builder, menu: admin, priority: 8 }

--- a/src/Elcodi/Admin/PluginBundle/Resources/config/categoriesMenu.yml
+++ b/src/Elcodi/Admin/PluginBundle/Resources/config/categoriesMenu.yml
@@ -1,0 +1,11 @@
+services:
+
+    #
+    # Add menu entries into each plugin category
+    #
+    elcodi_admin.menu_builder.plugin_categories:
+        class: Elcodi\Admin\PluginBundle\Builder\PluginCategoryMenuBuilder
+        arguments:
+            - @elcodi.factory.menu_node
+        tags:
+            - { name: menu.builder, menu: admin, priority: 16 }

--- a/src/Elcodi/Admin/PluginBundle/Resources/config/menu.yml
+++ b/src/Elcodi/Admin/PluginBundle/Resources/config/menu.yml
@@ -9,12 +9,3 @@ services:
             - @elcodi.factory.menu_node
         tags:
             - { name: menu.builder, menu: admin, priority: 32 }
-
-    elcodi_admin.menu_builder.plugins:
-        class: Elcodi\Admin\PluginBundle\Builder\PluginMenuBuilder
-        arguments:
-            - @elcodi.factory.menu_node
-            - @router
-            - @elcodi.enabled_plugins
-        tags:
-            - { name: menu.builder, menu: admin, priority: 16 }

--- a/src/Elcodi/Admin/PluginBundle/Resources/config/pluginMenu.yml
+++ b/src/Elcodi/Admin/PluginBundle/Resources/config/pluginMenu.yml
@@ -7,7 +7,6 @@ services:
         class: Elcodi\Admin\PluginBundle\Builder\PluginMenuBuilder
         arguments:
             - @elcodi.factory.menu_node
-            - @router
             - @elcodi.enabled_plugins
         tags:
             - { name: menu.builder, menu: admin, priority: 16 }

--- a/src/Elcodi/Admin/PluginBundle/Resources/config/pluginMenu.yml
+++ b/src/Elcodi/Admin/PluginBundle/Resources/config/pluginMenu.yml
@@ -1,0 +1,13 @@
+services:
+
+    #
+    # Add menu entries into each plugin category
+    #
+    elcodi_admin.menu_builder.plugin_entries:
+        class: Elcodi\Admin\PluginBundle\Builder\PluginMenuBuilder
+        arguments:
+            - @elcodi.factory.menu_node
+            - @router
+            - @elcodi.enabled_plugins
+        tags:
+            - { name: menu.builder, menu: admin, priority: 16 }

--- a/src/Elcodi/Admin/PluginBundle/Resources/views/Plugin/list.html.twig
+++ b/src/Elcodi/Admin/PluginBundle/Resources/views/Plugin/list.html.twig
@@ -13,7 +13,7 @@
         {% include '@AdminCore/Common/breadcrumb.html.twig' with {
             breadcrumb: [
                 { name: 'admin.plugin.plural'|trans, active: false },
-                { name: "plugin_type.#{category}.title"|trans, active: true },
+                { name: "plugin_type.#{category}"|trans, active: true },
             ]
         } %}
 

--- a/src/Elcodi/Admin/PluginBundle/Resources/views/Plugin/list.html.twig
+++ b/src/Elcodi/Admin/PluginBundle/Resources/views/Plugin/list.html.twig
@@ -8,11 +8,24 @@
 
 {% block breadcrumb %}
 
-    {% include '@AdminCore/Common/breadcrumb.html.twig' with {
-        breadcrumb: [
-            { name: 'admin.plugin.plural'|trans, active: true },
-        ]
-    } %}
+    {% if category %}
+
+        {% include '@AdminCore/Common/breadcrumb.html.twig' with {
+            breadcrumb: [
+                { name: 'admin.plugin.plural'|trans, active: false },
+                { name: "plugin_type.#{category}.title"|trans, active: true },
+            ]
+        } %}
+
+    {% else %}
+
+        {% include '@AdminCore/Common/breadcrumb.html.twig' with {
+            breadcrumb: [
+                { name: 'admin.plugin.plural'|trans, active: true },
+            ]
+        } %}
+
+    {% endif %}
 
 {% endblock breadcrumb %}
 
@@ -21,20 +34,27 @@
 
     <form class="form-grid form-grid-has-settings form-save-on-edit" data-fc-modules="form-save-on-edit">
         {% for plugin in plugins if plugin.getConfigurationValue('visible') %}
+
             {% set pluginName = plugin.getConfigurationValue('name')|trans %}
             {% set pluginDescription = plugin.getConfigurationValue('description')|trans|striptags %}
-            {% set iconPath = "/bundles" ~ asset(plugin.getBundleName()|replace({'Bundle': ''})|lower ~ "/images/icon.png") %}
+            {% set assetPath = 'bundles/' ~ plugin.bundleName|replace({'Bundle': ''})|lower %}
+            {% set iconPath = asset(assetPath ~ '/images/icon.png') %}
+
             <article class="box-background">
                 <img src="{{ iconPath }}" class="form-grid-background" />
                 <div class="box-none pa-n mb-n">
                     <img src="{{ iconPath }}" width="50" class="form-grid-icon" />
-                    <h4 class="fw-n">{{ pluginName }}</h4>
-                    <p data-fc-modules="truncate" data-fc-max="100" data-fc-more="+" data-fc-less="-">{{ pluginDescription }}</p>
-                    <input type="hidden" id="url-enable-plugin-{{ plugin.hash }}" value="{{ url('admin_plugin_enable', {pluginHash: plugin.hash}) }}" />
+                    <h4 class="fw-n">{{ pluginName|trans }}</h4>
+                    <p data-fc-modules="truncate" data-fc-max="100" data-fc-more="+" data-fc-less="-">
+                        {{ pluginDescription|trans }}
+                    </p>
+                    <input type="hidden" id="url-enable-plugin-{{ plugin.hash }}" value="{{ url('admin_plugin_enable', { pluginHash: plugin.hash }) }}" />
                 </div>
                 <div class="form-grid-settings">
                     {% if plugin.hasFields() %}
-                        <a href="{{ url('admin_plugin_configure', {pluginHash: plugin.hash}) }}" class="button icon-cogs"> {{ 'admin.plugin.section.settings'|trans }}</a>
+                        <a href="{{ url('admin_plugin_configure', { pluginHash: plugin.hash }) }}" class="button icon-cogs">
+                            {{ 'admin.plugin.section.settings'|trans }}
+                        </a>
                     {% endif %}
                     <div class="fl-r pt-s">
                         {{ 'admin.plugin.field.visibility'|trans }}

--- a/src/Elcodi/Admin/ShippingBundle/Builder/MenuBuilder.php
+++ b/src/Elcodi/Admin/ShippingBundle/Builder/MenuBuilder.php
@@ -38,7 +38,7 @@ class MenuBuilder extends AbstractMenuBuilder implements MenuBuilderInterface
                 $this
                     ->menuNodeFactory
                     ->create()
-                    ->setName('admin.carrier.plural')
+                    ->setName('plugin_type.shipping')
                     ->setTag('settings')
                     ->setCode('truck')
                     ->setPriority(30)

--- a/src/Elcodi/Plugin/CustomShippingBundle/Builder/MenuBuilder.php
+++ b/src/Elcodi/Plugin/CustomShippingBundle/Builder/MenuBuilder.php
@@ -34,7 +34,7 @@ class MenuBuilder extends AbstractMenuBuilder implements MenuBuilderInterface
     public function build(MenuInterface $menu)
     {
         $menu
-            ->findSubnodeByName('admin.carrier.plural')
+            ->findSubnodeByName('plugin_type.shipping')
             ->addSubnode(
                 $this
                     ->menuNodeFactory


### PR DESCRIPTION
Allow for different entries for each plugin type.
- `PluginController` now can work for a single plugin type.
- Special `MenuBuilder` to add entries for each plugin type.
- Allow configuration for enable/disable plugin menu builders.