### PR TITLE
PHP Redis dependency readded

### DIFF
--- a/README.md
+++ b/README.md
@@ -73,6 +73,8 @@ For more info just visit their
 In order to use the last Redis features, like the `HyperLogLog` commands, be
 sure your Redis version is at least `v2.8.9`.
 
+> Make sure to have Redis PHP extension installed.
+
 ## Installation
 
 If you're used to working with LAMP environment, then you will have Bamboo 

--- a/composer.json
+++ b/composer.json
@@ -32,6 +32,7 @@
     "require": {
         "php": ">=5.4",
         "ext-openssl": "*",
+        "ext-redis": "*",
 
         "symfony/symfony": "^2.7",
         "symfony/framework-bundle": "^2.7",


### PR DESCRIPTION
* We are actually using Predis in our installation, but DoctrineCacheBundle is not implementing the
  predis provider yet (PR opened but not merged)
* This change is temporary