### PR TITLE
Fixed money precision in some cases

### DIFF
--- a/src/Elcodi/Admin/CurrencyBundle/Form/DataMapper/MoneyDataMapper.php
+++ b/src/Elcodi/Admin/CurrencyBundle/Form/DataMapper/MoneyDataMapper.php
@@ -41,7 +41,7 @@ class MoneyDataMapper implements DataMapperInterface
         foreach ($forms as $form) {
             switch ($form->getName()) {
                 case 'amount':
-                    $form->setData($data->getAmount());
+                    $form->setData(bcdiv($data->getAmount(), 100, 2));
                     break;
                 case 'currency':
                     $form->setData($data->getCurrency());
@@ -62,7 +62,7 @@ class MoneyDataMapper implements DataMapperInterface
     {
         $forms = iterator_to_array($forms);
         $data = Money::create(
-            $forms['amount']->getData(),
+            bcmul($forms['amount']->getData(), 100),
             $forms['currency']->getData()
         );
     }

--- a/src/Elcodi/Admin/CurrencyBundle/Form/Type/MoneyType.php
+++ b/src/Elcodi/Admin/CurrencyBundle/Form/Type/MoneyType.php
@@ -65,9 +65,8 @@ class MoneyType extends AbstractType
     public function buildForm(FormBuilderInterface $builder, array $options)
     {
         $builder
-            ->add('amount', 'money', [
-                'divisor'  => 100,
-                'currency' => false,
+            ->add('amount', 'number', [
+                'scale'  => 2,
             ])
             ->add('currency', 'entity', [
                 'class'         => $this->currencyNamespace,


### PR DESCRIPTION
When a product price was set as 9.87, then the value was saved as 9.86. This
problem relies in how Symfony Forms plays with numbers, even when are decimals.
We've solved this by giving the responsibility of converting floats to integers
and viceversa to the MoneyDataMaper, so we can safely do that conversion.