### PR TITLE
[DX] Use AbstractElcodiBundle in Elcodi bundles

### DIFF
--- a/src/Elcodi/Admin/AttributeBundle/AdminAttributeBundle.php
+++ b/src/Elcodi/Admin/AttributeBundle/AdminAttributeBundle.php
@@ -17,16 +17,15 @@
 
 namespace Elcodi\Admin\AttributeBundle;
 
-use Symfony\Component\Console\Application;
 use Symfony\Component\DependencyInjection\Extension\ExtensionInterface;
-use Symfony\Component\HttpKernel\Bundle\Bundle;
 
+use Elcodi\Bundle\CoreBundle\Abstracts\AbstractElcodiBundle;
 use Elcodi\Admin\AttributeBundle\DependencyInjection\AdminAttributeExtension;
 
 /**
  * Class AdminAttributeBundle
  */
-class AdminAttributeBundle extends Bundle
+class AdminAttributeBundle extends AbstractElcodiBundle
 {
     /**
      * Returns the bundle's container extension.
@@ -36,19 +35,5 @@ class AdminAttributeBundle extends Bundle
     public function getContainerExtension()
     {
         return new AdminAttributeExtension();
-    }
-
-    /**
-     * Register Commands.
-     *
-     * Disabled as commands are registered as services.
-     *
-     * @param Application $application An Application instance
-     *
-     * @return null
-     */
-    public function registerCommands(Application $application)
-    {
-        return null;
     }
 }

--- a/src/Elcodi/Admin/BannerBundle/AdminBannerBundle.php
+++ b/src/Elcodi/Admin/BannerBundle/AdminBannerBundle.php
@@ -17,16 +17,15 @@
 
 namespace Elcodi\Admin\BannerBundle;
 
-use Symfony\Component\Console\Application;
 use Symfony\Component\DependencyInjection\Extension\ExtensionInterface;
-use Symfony\Component\HttpKernel\Bundle\Bundle;
 
 use Elcodi\Admin\BannerBundle\DependencyInjection\AdminBannerExtension;
+use Elcodi\Bundle\CoreBundle\Abstracts\AbstractElcodiBundle;
 
 /**
  * Class AdminBannerBundle
  */
-class AdminBannerBundle extends Bundle
+class AdminBannerBundle extends AbstractElcodiBundle
 {
     /**
      * Returns the bundle's container extension.
@@ -36,19 +35,5 @@ class AdminBannerBundle extends Bundle
     public function getContainerExtension()
     {
         return new AdminBannerExtension();
-    }
-
-    /**
-     * Register Commands.
-     *
-     * Disabled as commands are registered as services.
-     *
-     * @param Application $application An Application instance
-     *
-     * @return null
-     */
-    public function registerCommands(Application $application)
-    {
-        return null;
     }
 }

--- a/src/Elcodi/Admin/CartBundle/AdminCartBundle.php
+++ b/src/Elcodi/Admin/CartBundle/AdminCartBundle.php
@@ -17,16 +17,15 @@
 
 namespace Elcodi\Admin\CartBundle;
 
-use Symfony\Component\Console\Application;
 use Symfony\Component\DependencyInjection\Extension\ExtensionInterface;
-use Symfony\Component\HttpKernel\Bundle\Bundle;
 
 use Elcodi\Admin\CartBundle\DependencyInjection\AdminCartExtension;
+use Elcodi\Bundle\CoreBundle\Abstracts\AbstractElcodiBundle;
 
 /**
  * Class AdminCartBundle
  */
-class AdminCartBundle extends Bundle
+class AdminCartBundle extends AbstractElcodiBundle
 {
     /**
      * Returns the bundle's container extension.
@@ -36,19 +35,5 @@ class AdminCartBundle extends Bundle
     public function getContainerExtension()
     {
         return new AdminCartExtension();
-    }
-
-    /**
-     * Register Commands.
-     *
-     * Disabled as commands are registered as services.
-     *
-     * @param Application $application An Application instance
-     *
-     * @return null
-     */
-    public function registerCommands(Application $application)
-    {
-        return null;
     }
 }

--- a/src/Elcodi/Admin/CoreBundle/AdminCoreBundle.php
+++ b/src/Elcodi/Admin/CoreBundle/AdminCoreBundle.php
@@ -18,14 +18,14 @@
 namespace Elcodi\Admin\CoreBundle;
 
 use Symfony\Component\Console\Application;
-use Symfony\Component\HttpKernel\Bundle\Bundle;
 
 use Elcodi\Admin\CoreBundle\DependencyInjection\AdminCoreExtension;
+use Elcodi\Bundle\CoreBundle\Abstracts\AbstractElcodiBundle;
 
 /**
  * Class AdminCoreBundle
  */
-class AdminCoreBundle extends Bundle
+class AdminCoreBundle extends AbstractElcodiBundle
 {
     /**
      * Returns the bundle's container extension.

--- a/src/Elcodi/Admin/CouponBundle/AdminCouponBundle.php
+++ b/src/Elcodi/Admin/CouponBundle/AdminCouponBundle.php
@@ -17,16 +17,15 @@
 
 namespace Elcodi\Admin\CouponBundle;
 
-use Symfony\Component\Console\Application;
 use Symfony\Component\DependencyInjection\Extension\ExtensionInterface;
-use Symfony\Component\HttpKernel\Bundle\Bundle;
 
 use Elcodi\Admin\CouponBundle\DependencyInjection\AdminCouponExtension;
+use Elcodi\Bundle\CoreBundle\Abstracts\AbstractElcodiBundle;
 
 /**
  * Class AdminCouponBundle
  */
-class AdminCouponBundle extends Bundle
+class AdminCouponBundle extends AbstractElcodiBundle
 {
     /**
      * Returns the bundle's container extension.
@@ -36,19 +35,5 @@ class AdminCouponBundle extends Bundle
     public function getContainerExtension()
     {
         return new AdminCouponExtension();
-    }
-
-    /**
-     * Register Commands.
-     *
-     * Disabled as commands are registered as services.
-     *
-     * @param Application $application An Application instance
-     *
-     * @return null
-     */
-    public function registerCommands(Application $application)
-    {
-        return null;
     }
 }

--- a/src/Elcodi/Admin/CurrencyBundle/AdminCurrencyBundle.php
+++ b/src/Elcodi/Admin/CurrencyBundle/AdminCurrencyBundle.php
@@ -17,16 +17,15 @@
 
 namespace Elcodi\Admin\CurrencyBundle;
 
-use Symfony\Component\Console\Application;
 use Symfony\Component\DependencyInjection\Extension\ExtensionInterface;
-use Symfony\Component\HttpKernel\Bundle\Bundle;
 
 use Elcodi\Admin\CurrencyBundle\DependencyInjection\AdminCurrencyExtension;
+use Elcodi\Bundle\CoreBundle\Abstracts\AbstractElcodiBundle;
 
 /**
  * Class AdminCurrencyBundle
  */
-class AdminCurrencyBundle extends Bundle
+class AdminCurrencyBundle extends AbstractElcodiBundle
 {
     /**
      * Returns the bundle's container extension.
@@ -36,19 +35,5 @@ class AdminCurrencyBundle extends Bundle
     public function getContainerExtension()
     {
         return new AdminCurrencyExtension();
-    }
-
-    /**
-     * Register Commands.
-     *
-     * Disabled as commands are registered as services.
-     *
-     * @param Application $application An Application instance
-     *
-     * @return null
-     */
-    public function registerCommands(Application $application)
-    {
-        return null;
     }
 }

--- a/src/Elcodi/Admin/GeoBundle/AdminGeoBundle.php
+++ b/src/Elcodi/Admin/GeoBundle/AdminGeoBundle.php
@@ -17,16 +17,15 @@
 
 namespace Elcodi\Admin\GeoBundle;
 
-use Symfony\Component\Console\Application;
 use Symfony\Component\DependencyInjection\Extension\ExtensionInterface;
-use Symfony\Component\HttpKernel\Bundle\Bundle;
 
 use Elcodi\Admin\GeoBundle\DependencyInjection\AdminGeoExtension;
+use Elcodi\Bundle\CoreBundle\Abstracts\AbstractElcodiBundle;
 
 /**
  * Class AdminGeoBundle
  */
-class AdminGeoBundle extends Bundle
+class AdminGeoBundle extends AbstractElcodiBundle
 {
     /**
      * Returns the bundle's container extension.
@@ -36,19 +35,5 @@ class AdminGeoBundle extends Bundle
     public function getContainerExtension()
     {
         return new AdminGeoExtension();
-    }
-
-    /**
-     * Register Commands.
-     *
-     * Disabled as commands are registered as services.
-     *
-     * @param Application $application An Application instance
-     *
-     * @return null
-     */
-    public function registerCommands(Application $application)
-    {
-        return null;
     }
 }

--- a/src/Elcodi/Admin/LanguageBundle/AdminLanguageBundle.php
+++ b/src/Elcodi/Admin/LanguageBundle/AdminLanguageBundle.php
@@ -17,16 +17,15 @@
 
 namespace Elcodi\Admin\LanguageBundle;
 
-use Symfony\Component\Console\Application;
 use Symfony\Component\DependencyInjection\Extension\ExtensionInterface;
-use Symfony\Component\HttpKernel\Bundle\Bundle;
 
 use Elcodi\Admin\LanguageBundle\DependencyInjection\AdminLanguageExtension;
+use Elcodi\Bundle\CoreBundle\Abstracts\AbstractElcodiBundle;
 
 /**
  * Class AdminLanguageBundle
  */
-class AdminLanguageBundle extends Bundle
+class AdminLanguageBundle extends AbstractElcodiBundle
 {
     /**
      * Returns the bundle's container extension.
@@ -36,19 +35,5 @@ class AdminLanguageBundle extends Bundle
     public function getContainerExtension()
     {
         return new AdminLanguageExtension();
-    }
-
-    /**
-     * Register Commands.
-     *
-     * Disabled as commands are registered as services.
-     *
-     * @param Application $application An Application instance
-     *
-     * @return null
-     */
-    public function registerCommands(Application $application)
-    {
-        return null;
     }
 }

--- a/src/Elcodi/Admin/MediaBundle/AdminMediaBundle.php
+++ b/src/Elcodi/Admin/MediaBundle/AdminMediaBundle.php
@@ -17,16 +17,15 @@
 
 namespace Elcodi\Admin\MediaBundle;
 
-use Symfony\Component\Console\Application;
 use Symfony\Component\DependencyInjection\Extension\ExtensionInterface;
-use Symfony\Component\HttpKernel\Bundle\Bundle;
 
 use Elcodi\Admin\MediaBundle\DependencyInjection\AdminMediaExtension;
+use Elcodi\Bundle\CoreBundle\Abstracts\AbstractElcodiBundle;
 
 /**
  * Class AdminMediaBundle
  */
-class AdminMediaBundle extends Bundle
+class AdminMediaBundle extends AbstractElcodiBundle
 {
     /**
      * Returns the bundle's container extension.
@@ -36,19 +35,5 @@ class AdminMediaBundle extends Bundle
     public function getContainerExtension()
     {
         return new AdminMediaExtension();
-    }
-
-    /**
-     * Register Commands.
-     *
-     * Disabled as commands are registered as services.
-     *
-     * @param Application $application An Application instance
-     *
-     * @return null
-     */
-    public function registerCommands(Application $application)
-    {
-        return null;
     }
 }

--- a/src/Elcodi/Admin/MetricBundle/AdminMetricBundle.php
+++ b/src/Elcodi/Admin/MetricBundle/AdminMetricBundle.php
@@ -17,16 +17,15 @@
 
 namespace Elcodi\Admin\MetricBundle;
 
-use Symfony\Component\Console\Application;
-use Symfony\Component\CssSelector\XPath\Extension\ExtensionInterface;
-use Symfony\Component\HttpKernel\Bundle\Bundle;
+use Symfony\Component\DependencyInjection\Extension\ExtensionInterface;
 
 use Elcodi\Admin\MetricBundle\DependencyInjection\AdminMetricExtension;
+use Elcodi\Bundle\CoreBundle\Abstracts\AbstractElcodiBundle;
 
 /**
  * Class AdminMetricBundle
  */
-class AdminMetricBundle extends Bundle
+class AdminMetricBundle extends AbstractElcodiBundle
 {
     /**
      * Returns the bundle's container extension.
@@ -36,19 +35,5 @@ class AdminMetricBundle extends Bundle
     public function getContainerExtension()
     {
         return new AdminMetricExtension();
-    }
-
-    /**
-     * Register Commands.
-     *
-     * Disabled as commands are registered as services.
-     *
-     * @param Application $application An Application instance
-     *
-     * @return null
-     */
-    public function registerCommands(Application $application)
-    {
-        return null;
     }
 }

--- a/src/Elcodi/Admin/NewsletterBundle/AdminNewsletterBundle.php
+++ b/src/Elcodi/Admin/NewsletterBundle/AdminNewsletterBundle.php
@@ -17,16 +17,15 @@
 
 namespace Elcodi\Admin\NewsletterBundle;
 
-use Symfony\Component\Console\Application;
 use Symfony\Component\DependencyInjection\Extension\ExtensionInterface;
-use Symfony\Component\HttpKernel\Bundle\Bundle;
 
 use Elcodi\Admin\NewsletterBundle\DependencyInjection\AdminNewsletterExtension;
+use Elcodi\Bundle\CoreBundle\Abstracts\AbstractElcodiBundle;
 
 /**
  * Class AdminNewsletterBundle
  */
-class AdminNewsletterBundle extends Bundle
+class AdminNewsletterBundle extends AbstractElcodiBundle
 {
     /**
      * Returns the bundle's container extension.
@@ -36,19 +35,5 @@ class AdminNewsletterBundle extends Bundle
     public function getContainerExtension()
     {
         return new AdminNewsletterExtension();
-    }
-
-    /**
-     * Register Commands.
-     *
-     * Disabled as commands are registered as services.
-     *
-     * @param Application $application An Application instance
-     *
-     * @return null
-     */
-    public function registerCommands(Application $application)
-    {
-        return null;
     }
 }

--- a/src/Elcodi/Admin/PageBundle/AdminPageBundle.php
+++ b/src/Elcodi/Admin/PageBundle/AdminPageBundle.php
@@ -17,16 +17,15 @@
 
 namespace Elcodi\Admin\PageBundle;
 
-use Symfony\Component\Console\Application;
 use Symfony\Component\DependencyInjection\Extension\ExtensionInterface;
-use Symfony\Component\HttpKernel\Bundle\Bundle;
 
 use Elcodi\Admin\PageBundle\DependencyInjection\AdminPageExtension;
+use Elcodi\Bundle\CoreBundle\Abstracts\AbstractElcodiBundle;
 
 /**
  * Class AdminPageBundle
  */
-class AdminPageBundle extends Bundle
+class AdminPageBundle extends AbstractElcodiBundle
 {
     /**
      * Returns the bundle's container extension.
@@ -36,19 +35,5 @@ class AdminPageBundle extends Bundle
     public function getContainerExtension()
     {
         return new AdminPageExtension();
-    }
-
-    /**
-     * Register Commands.
-     *
-     * Disabled as commands are registered as services.
-     *
-     * @param Application $application An Application instance
-     *
-     * @return null
-     */
-    public function registerCommands(Application $application)
-    {
-        return null;
     }
 }

--- a/src/Elcodi/Admin/PaymentBundle/AdminPaymentBundle.php
+++ b/src/Elcodi/Admin/PaymentBundle/AdminPaymentBundle.php
@@ -17,18 +17,17 @@
 
 namespace Elcodi\Admin\PaymentBundle;
 
-use Symfony\Component\Console\Application;
 use Symfony\Component\DependencyInjection\Extension\ExtensionInterface;
-use Symfony\Component\HttpKernel\Bundle\Bundle;
 use Symfony\Component\HttpKernel\KernelInterface;
 
 use Elcodi\Admin\PaymentBundle\DependencyInjection\AdminPaymentExtension;
+use Elcodi\Bundle\CoreBundle\Abstracts\AbstractElcodiBundle;
 use Elcodi\Bundle\CoreBundle\Interfaces\DependentBundleInterface;
 
 /**
  * Class AdminPaymentBundle
  */
-class AdminPaymentBundle extends Bundle implements DependentBundleInterface
+class AdminPaymentBundle extends AbstractElcodiBundle implements DependentBundleInterface
 {
     /**
      * Returns the bundle's container extension.
@@ -38,20 +37,6 @@ class AdminPaymentBundle extends Bundle implements DependentBundleInterface
     public function getContainerExtension()
     {
         return new AdminPaymentExtension();
-    }
-
-    /**
-     * Register Commands.
-     *
-     * Disabled as commands are registered as services.
-     *
-     * @param Application $application An Application instance
-     *
-     * @return null
-     */
-    public function registerCommands(Application $application)
-    {
-        return null;
     }
 
     /**

--- a/src/Elcodi/Admin/PluginBundle/AdminPluginBundle.php
+++ b/src/Elcodi/Admin/PluginBundle/AdminPluginBundle.php
@@ -17,37 +17,23 @@
 
 namespace Elcodi\Admin\PluginBundle;
 
-use Symfony\Component\Console\Application;
-use Symfony\Component\HttpKernel\Bundle\Bundle;
+use Symfony\Component\DependencyInjection\Extension\ExtensionInterface;
 
 use Elcodi\Admin\PluginBundle\DependencyInjection\AdminPluginExtension;
+use Elcodi\Bundle\CoreBundle\Abstracts\AbstractElcodiBundle;
 
 /**
  * Class AdminPluginBundle
  */
-class AdminPluginBundle extends Bundle
+class AdminPluginBundle extends AbstractElcodiBundle
 {
     /**
      * Returns the bundle's container extension.
      *
-     * @return AdminPluginExtension
+     * @return ExtensionInterface
      */
     public function getContainerExtension()
     {
         return new AdminPluginExtension();
-    }
-
-    /**
-     * Register Commands.
-     *
-     * Disabled as commands are registered as services.
-     *
-     * @param Application $application An Application instance
-     *
-     * @return null
-     */
-    public function registerCommands(Application $application)
-    {
-        return null;
     }
 }

--- a/src/Elcodi/Admin/ProductBundle/AdminProductBundle.php
+++ b/src/Elcodi/Admin/ProductBundle/AdminProductBundle.php
@@ -17,16 +17,15 @@
 
 namespace Elcodi\Admin\ProductBundle;
 
-use Symfony\Component\Console\Application;
 use Symfony\Component\DependencyInjection\Extension\ExtensionInterface;
-use Symfony\Component\HttpKernel\Bundle\Bundle;
 
 use Elcodi\Admin\ProductBundle\DependencyInjection\AdminProductExtension;
+use Elcodi\Bundle\CoreBundle\Abstracts\AbstractElcodiBundle;
 
 /**
  * Class AdminProductBundle
  */
-class AdminProductBundle extends Bundle
+class AdminProductBundle extends AbstractElcodiBundle
 {
     /**
      * Returns the bundle's container extension.
@@ -36,19 +35,5 @@ class AdminProductBundle extends Bundle
     public function getContainerExtension()
     {
         return new AdminProductExtension();
-    }
-
-    /**
-     * Register Commands.
-     *
-     * Disabled as commands are registered as services.
-     *
-     * @param Application $application An Application instance
-     *
-     * @return null
-     */
-    public function registerCommands(Application $application)
-    {
-        return null;
     }
 }

--- a/src/Elcodi/Admin/RuleBundle/AdminRuleBundle.php
+++ b/src/Elcodi/Admin/RuleBundle/AdminRuleBundle.php
@@ -17,16 +17,16 @@
 
 namespace Elcodi\Admin\RuleBundle;
 
-use Symfony\Component\Console\Application;
 use Symfony\Component\DependencyInjection\Extension\ExtensionInterface;
-use Symfony\Component\HttpKernel\Bundle\Bundle;
 
+use Elcodi\Admin\CoreBundle\Bundle\Bundle;
 use Elcodi\Admin\RuleBundle\DependencyInjection\AdminRuleExtension;
+use Elcodi\Bundle\CoreBundle\Abstracts\AbstractElcodiBundle;
 
 /**
  * Class AdminRuleBundle
  */
-class AdminRuleBundle extends Bundle
+class AdminRuleBundle extends AbstractElcodiBundle
 {
     /**
      * Returns the bundle's container extension.
@@ -36,19 +36,5 @@ class AdminRuleBundle extends Bundle
     public function getContainerExtension()
     {
         return new AdminRuleExtension();
-    }
-
-    /**
-     * Register Commands.
-     *
-     * Disabled as commands are registered as services.
-     *
-     * @param Application $application An Application instance
-     *
-     * @return null
-     */
-    public function registerCommands(Application $application)
-    {
-        return null;
     }
 }

--- a/src/Elcodi/Admin/ShippingBundle/AdminShippingBundle.php
+++ b/src/Elcodi/Admin/ShippingBundle/AdminShippingBundle.php
@@ -17,16 +17,15 @@
 
 namespace Elcodi\Admin\ShippingBundle;
 
-use Symfony\Component\Console\Application;
 use Symfony\Component\DependencyInjection\Extension\ExtensionInterface;
-use Symfony\Component\HttpKernel\Bundle\Bundle;
 
 use Elcodi\Admin\ShippingBundle\DependencyInjection\AdminShippingExtension;
+use Elcodi\Bundle\CoreBundle\Abstracts\AbstractElcodiBundle;
 
 /**
  * Class AdminShippingBundle
  */
-class AdminShippingBundle extends Bundle
+class AdminShippingBundle extends AbstractElcodiBundle
 {
     /**
      * Returns the bundle's container extension.
@@ -36,19 +35,5 @@ class AdminShippingBundle extends Bundle
     public function getContainerExtension()
     {
         return new AdminShippingExtension();
-    }
-
-    /**
-     * Register Commands.
-     *
-     * Disabled as commands are registered as services.
-     *
-     * @param Application $application An Application instance
-     *
-     * @return null
-     */
-    public function registerCommands(Application $application)
-    {
-        return null;
     }
 }

--- a/src/Elcodi/Admin/StoreBundle/AdminStoreBundle.php
+++ b/src/Elcodi/Admin/StoreBundle/AdminStoreBundle.php
@@ -17,18 +17,17 @@
 
 namespace Elcodi\Admin\StoreBundle;
 
-use Symfony\Component\Console\Application;
 use Symfony\Component\DependencyInjection\Extension\ExtensionInterface;
-use Symfony\Component\HttpKernel\Bundle\Bundle;
 use Symfony\Component\HttpKernel\KernelInterface;
 
 use Elcodi\Admin\StoreBundle\DependencyInjection\AdminStoreExtension;
+use Elcodi\Bundle\CoreBundle\Abstracts\AbstractElcodiBundle;
 use Elcodi\Bundle\CoreBundle\Interfaces\DependentBundleInterface;
 
 /**
  * Class AdminStoreBundle
  */
-class AdminStoreBundle extends Bundle implements DependentBundleInterface
+class AdminStoreBundle extends AbstractElcodiBundle implements DependentBundleInterface
 {
     /**
      * Returns the bundle's container extension.
@@ -38,20 +37,6 @@ class AdminStoreBundle extends Bundle implements DependentBundleInterface
     public function getContainerExtension()
     {
         return new AdminStoreExtension();
-    }
-
-    /**
-     * Register Commands.
-     *
-     * Disabled as commands are registered as services.
-     *
-     * @param Application $application An Application instance
-     *
-     * @return null
-     */
-    public function registerCommands(Application $application)
-    {
-        return null;
     }
 
     /**

--- a/src/Elcodi/Admin/TemplateBundle/AdminTemplateBundle.php
+++ b/src/Elcodi/Admin/TemplateBundle/AdminTemplateBundle.php
@@ -17,37 +17,23 @@
 
 namespace Elcodi\Admin\TemplateBundle;
 
-use Symfony\Component\Console\Application;
-use Symfony\Component\HttpKernel\Bundle\Bundle;
+use Symfony\Component\DependencyInjection\Extension\ExtensionInterface;
 
 use Elcodi\Admin\TemplateBundle\DependencyInjection\AdminTemplateExtension;
+use Elcodi\Bundle\CoreBundle\Abstracts\AbstractElcodiBundle;
 
 /**
  * Class AdminTemplateBundle
  */
-class AdminTemplateBundle extends Bundle
+class AdminTemplateBundle extends AbstractElcodiBundle
 {
     /**
      * Returns the bundle's container extension.
      *
-     * @return null
+     * @return ExtensionInterface The container extension
      */
     public function getContainerExtension()
     {
         return new AdminTemplateExtension();
-    }
-
-    /**
-     * Register Commands.
-     *
-     * Disabled as commands are registered as services.
-     *
-     * @param Application $application An Application instance
-     *
-     * @return null
-     */
-    public function registerCommands(Application $application)
-    {
-        return null;
     }
 }

--- a/src/Elcodi/Admin/UserBundle/AdminUserBundle.php
+++ b/src/Elcodi/Admin/UserBundle/AdminUserBundle.php
@@ -17,16 +17,15 @@
 
 namespace Elcodi\Admin\UserBundle;
 
-use Symfony\Component\Console\Application;
 use Symfony\Component\DependencyInjection\Extension\ExtensionInterface;
-use Symfony\Component\HttpKernel\Bundle\Bundle;
 
 use Elcodi\Admin\UserBundle\DependencyInjection\AdminUserExtension;
+use Elcodi\Bundle\CoreBundle\Abstracts\AbstractElcodiBundle;
 
 /**
  * Class AdminUserBundle
  */
-class AdminUserBundle extends Bundle
+class AdminUserBundle extends AbstractElcodiBundle
 {
     /**
      * Returns the bundle's container extension.
@@ -36,19 +35,5 @@ class AdminUserBundle extends Bundle
     public function getContainerExtension()
     {
         return new AdminUserExtension();
-    }
-
-    /**
-     * Register Commands.
-     *
-     * Disabled as commands are registered as services.
-     *
-     * @param Application $application An Application instance
-     *
-     * @return null
-     */
-    public function registerCommands(Application $application)
-    {
-        return null;
     }
 }


### PR DESCRIPTION
Hi,

this is to avoid the boring implementation of ``registerCommands`` in each commands.

Regards,
