### PR TITLE
Fix enable product

### DIFF
--- a/src/Elcodi/Admin/CoreBundle/Controller/Abstracts/AbstractAdminController.php
+++ b/src/Elcodi/Admin/CoreBundle/Controller/Abstracts/AbstractAdminController.php
@@ -49,7 +49,7 @@ class AbstractAdminController extends Controller
             /**
              * @var EnabledInterface $entity
              */
-            $$this->enableEntity($entity);
+            $this->enableEntity($entity);
         });
     }
 


### PR DESCRIPTION
Fixes the `Object of class ProductController could not be converted to string` error when browsing to `/product/{id}/enable`.