### PR TITLE
Moved form type name into `getBlockPrefix`

### DIFF
--- a/src/Elcodi/Admin/AttributeBundle/Form/Type/AttributeType.php
+++ b/src/Elcodi/Admin/AttributeBundle/Form/Type/AttributeType.php
@@ -67,12 +67,27 @@ class AttributeType extends AbstractType
     }
 
     /**
+     * Returns the prefix of the template block name for this type.
+     *
+     * The block prefix defaults to the underscored short class name with
+     * the "Type" suffix removed (e.g. "UserProfileType" => "user_profile").
+     *
+     * @return string The prefix of the template block name
+     */
+    public function getBlockPrefix()
+    {
+        return 'elcodi_admin_attribute_form_type_attribute';
+    }
+
+    /**
      * Return unique name for this form
+     *
+     * @deprecated Deprecated since Symfony 2.8, to be removed from Symfony 3.
      *
      * @return string
      */
     public function getName()
     {
-        return 'elcodi_admin_attribute_form_type_attribute';
+        return $this->getBlockPrefix();
     }
 }

--- a/src/Elcodi/Admin/BannerBundle/Form/Type/BannerType.php
+++ b/src/Elcodi/Admin/BannerBundle/Form/Type/BannerType.php
@@ -125,12 +125,27 @@ class BannerType extends AbstractType
     }
 
     /**
+     * Returns the prefix of the template block name for this type.
+     *
+     * The block prefix defaults to the underscored short class name with
+     * the "Type" suffix removed (e.g. "UserProfileType" => "user_profile").
+     *
+     * @return string The prefix of the template block name
+     */
+    public function getBlockPrefix()
+    {
+        return 'elcodi_admin_banner_form_type_banner';
+    }
+
+    /**
      * Return unique name for this form
+     *
+     * @deprecated Deprecated since Symfony 2.8, to be removed from Symfony 3.
      *
      * @return string
      */
     public function getName()
     {
-        return 'elcodi_admin_banner_form_type_banner';
+        return $this->getBlockPrefix();
     }
 }

--- a/src/Elcodi/Admin/BannerBundle/Form/Type/BannerZoneType.php
+++ b/src/Elcodi/Admin/BannerBundle/Form/Type/BannerZoneType.php
@@ -115,12 +115,27 @@ class BannerZoneType extends AbstractType
     }
 
     /**
+     * Returns the prefix of the template block name for this type.
+     *
+     * The block prefix defaults to the underscored short class name with
+     * the "Type" suffix removed (e.g. "UserProfileType" => "user_profile").
+     *
+     * @return string The prefix of the template block name
+     */
+    public function getBlockPrefix()
+    {
+        return 'elcodi_admin_banner_form_type_banner_zone';
+    }
+
+    /**
      * Return unique name for this form
+     *
+     * @deprecated Deprecated since Symfony 2.8, to be removed from Symfony 3.
      *
      * @return string
      */
     public function getName()
     {
-        return 'elcodi_admin_banner_form_type_banner_zone';
+        return $this->getBlockPrefix();
     }
 }

--- a/src/Elcodi/Admin/CouponBundle/Form/Type/CouponType.php
+++ b/src/Elcodi/Admin/CouponBundle/Form/Type/CouponType.php
@@ -142,12 +142,27 @@ class CouponType extends AbstractType
     }
 
     /**
+     * Returns the prefix of the template block name for this type.
+     *
+     * The block prefix defaults to the underscored short class name with
+     * the "Type" suffix removed (e.g. "UserProfileType" => "user_profile").
+     *
+     * @return string The prefix of the template block name
+     */
+    public function getBlockPrefix()
+    {
+        return 'elcodi_admin_coupon_form_type_coupon';
+    }
+
+    /**
      * Return unique name for this form
+     *
+     * @deprecated Deprecated since Symfony 2.8, to be removed from Symfony 3.
      *
      * @return string
      */
     public function getName()
     {
-        return 'elcodi_admin_coupon_form_type_coupon';
+        return $this->getBlockPrefix();
     }
 }

--- a/src/Elcodi/Admin/CurrencyBundle/Form/Type/CurrencyType.php
+++ b/src/Elcodi/Admin/CurrencyBundle/Form/Type/CurrencyType.php
@@ -73,12 +73,27 @@ class CurrencyType extends AbstractType
     }
 
     /**
+     * Returns the prefix of the template block name for this type.
+     *
+     * The block prefix defaults to the underscored short class name with
+     * the "Type" suffix removed (e.g. "UserProfileType" => "user_profile").
+     *
+     * @return string The prefix of the template block name
+     */
+    public function getBlockPrefix()
+    {
+        return 'elcodi_admin_currency_form_type_currency';
+    }
+
+    /**
      * Return unique name for this form
+     *
+     * @deprecated Deprecated since Symfony 2.8, to be removed from Symfony 3.
      *
      * @return string
      */
     public function getName()
     {
-        return 'elcodi_admin_currency_form_type_currency';
+        return $this->getBlockPrefix();
     }
 }

--- a/src/Elcodi/Admin/CurrencyBundle/Form/Type/MoneyType.php
+++ b/src/Elcodi/Admin/CurrencyBundle/Form/Type/MoneyType.php
@@ -102,12 +102,27 @@ class MoneyType extends AbstractType
     }
 
     /**
+     * Returns the prefix of the template block name for this type.
+     *
+     * The block prefix defaults to the underscored short class name with
+     * the "Type" suffix removed (e.g. "UserProfileType" => "user_profile").
+     *
+     * @return string The prefix of the template block name
+     */
+    public function getBlockPrefix()
+    {
+        return 'money_object';
+    }
+
+    /**
      * Returns the name of this type.
+     *
+     * @deprecated Deprecated since Symfony 2.8, to be removed from Symfony 3.
      *
      * @return string The name of this type
      */
     public function getName()
     {
-        return 'money_object';
+        return $this->getBlockPrefix();
     }
 }

--- a/src/Elcodi/Admin/GeoBundle/Form/Type/AddressType.php
+++ b/src/Elcodi/Admin/GeoBundle/Form/Type/AddressType.php
@@ -92,12 +92,27 @@ class AddressType extends AbstractType
     }
 
     /**
+     * Returns the prefix of the template block name for this type.
+     *
+     * The block prefix defaults to the underscored short class name with
+     * the "Type" suffix removed (e.g. "UserProfileType" => "user_profile").
+     *
+     * @return string The prefix of the template block name
+     */
+    public function getBlockPrefix()
+    {
+        return 'admin_geo_form_type_address';
+    }
+
+    /**
      * Return unique name for this form
+     *
+     * @deprecated Deprecated since Symfony 2.8, to be removed from Symfony 3.
      *
      * @return string
      */
     public function getName()
     {
-        return 'admin_geo_form_type_address';
+        return $this->getBlockPrefix();
     }
 }

--- a/src/Elcodi/Admin/NewsletterBundle/Form/Type/NewsletterSubscriptionType.php
+++ b/src/Elcodi/Admin/NewsletterBundle/Form/Type/NewsletterSubscriptionType.php
@@ -95,12 +95,27 @@ class NewsletterSubscriptionType extends AbstractType
     }
 
     /**
+     * Returns the prefix of the template block name for this type.
+     *
+     * The block prefix defaults to the underscored short class name with
+     * the "Type" suffix removed (e.g. "UserProfileType" => "user_profile").
+     *
+     * @return string The prefix of the template block name
+     */
+    public function getBlockPrefix()
+    {
+        return 'elcodi_admin_newsletter_form_type_newsletter_subscription';
+    }
+
+    /**
      * Return unique name for this form
+     *
+     * @deprecated Deprecated since Symfony 2.8, to be removed from Symfony 3.
      *
      * @return string
      */
     public function getName()
     {
-        return 'elcodi_admin_newsletter_form_type_newsletter_subscription';
+        return $this->getBlockPrefix();
     }
 }

--- a/src/Elcodi/Admin/PageBundle/Form/Type/BlogPostType.php
+++ b/src/Elcodi/Admin/PageBundle/Form/Type/BlogPostType.php
@@ -103,12 +103,27 @@ class BlogPostType extends AbstractType
     }
 
     /**
+     * Returns the prefix of the template block name for this type.
+     *
+     * The block prefix defaults to the underscored short class name with
+     * the "Type" suffix removed (e.g. "UserProfileType" => "user_profile").
+     *
+     * @return string The prefix of the template block name
+     */
+    public function getBlockPrefix()
+    {
+        return 'elcodi_admin_page_form_type_blog_post';
+    }
+
+    /**
      * Return unique name for this form
+     *
+     * @deprecated Deprecated since Symfony 2.8, to be removed from Symfony 3.
      *
      * @return string
      */
     public function getName()
     {
-        return 'elcodi_admin_page_form_type_blog_post';
+        return $this->getBlockPrefix();
     }
 }

--- a/src/Elcodi/Admin/PageBundle/Form/Type/EmailType.php
+++ b/src/Elcodi/Admin/PageBundle/Form/Type/EmailType.php
@@ -77,12 +77,27 @@ class EmailType extends AbstractType
     }
 
     /**
+     * Returns the prefix of the template block name for this type.
+     *
+     * The block prefix defaults to the underscored short class name with
+     * the "Type" suffix removed (e.g. "UserProfileType" => "user_profile").
+     *
+     * @return string The prefix of the template block name
+     */
+    public function getBlockPrefix()
+    {
+        return 'elcodi_admin_page_form_type_email';
+    }
+
+    /**
      * Return unique name for this form
+     *
+     * @deprecated Deprecated since Symfony 2.8, to be removed from Symfony 3.
      *
      * @return string
      */
     public function getName()
     {
-        return 'elcodi_admin_page_form_type_email';
+        return $this->getBlockPrefix();
     }
 }

--- a/src/Elcodi/Admin/PageBundle/Form/Type/PageType.php
+++ b/src/Elcodi/Admin/PageBundle/Form/Type/PageType.php
@@ -109,12 +109,27 @@ class PageType extends AbstractType
     }
 
     /**
+     * Returns the prefix of the template block name for this type.
+     *
+     * The block prefix defaults to the underscored short class name with
+     * the "Type" suffix removed (e.g. "UserProfileType" => "user_profile").
+     *
+     * @return string The prefix of the template block name
+     */
+    public function getBlockPrefix()
+    {
+        return 'elcodi_admin_page_form_type_page';
+    }
+
+    /**
      * Return unique name for this form
+     *
+     * @deprecated Deprecated since Symfony 2.8, to be removed from Symfony 3.
      *
      * @return string
      */
     public function getName()
     {
-        return 'elcodi_admin_page_form_type_page';
+        return $this->getBlockPrefix();
     }
 }

--- a/src/Elcodi/Admin/ProductBundle/Form/Type/CategoryType.php
+++ b/src/Elcodi/Admin/ProductBundle/Form/Type/CategoryType.php
@@ -143,12 +143,27 @@ class CategoryType extends AbstractType
     }
 
     /**
+     * Returns the prefix of the template block name for this type.
+     *
+     * The block prefix defaults to the underscored short class name with
+     * the "Type" suffix removed (e.g. "UserProfileType" => "user_profile").
+     *
+     * @return string The prefix of the template block name
+     */
+    public function getBlockPrefix()
+    {
+        return 'elcodi_admin_product_form_type_category';
+    }
+
+    /**
      * Return unique name for this form
+     *
+     * @deprecated Deprecated since Symfony 2.8, to be removed from Symfony 3.
      *
      * @return string
      */
     public function getName()
     {
-        return 'elcodi_admin_product_form_type_category';
+        return $this->getBlockPrefix();
     }
 }

--- a/src/Elcodi/Admin/ProductBundle/Form/Type/ManufacturerType.php
+++ b/src/Elcodi/Admin/ProductBundle/Form/Type/ManufacturerType.php
@@ -134,12 +134,27 @@ class ManufacturerType extends AbstractType
     }
 
     /**
+     * Returns the prefix of the template block name for this type.
+     *
+     * The block prefix defaults to the underscored short class name with
+     * the "Type" suffix removed (e.g. "UserProfileType" => "user_profile").
+     *
+     * @return string The prefix of the template block name
+     */
+    public function getBlockPrefix()
+    {
+        return 'elcodi_admin_product_form_type_manufacturer';
+    }
+
+    /**
      * Return unique name for this form
+     *
+     * @deprecated Deprecated since Symfony 2.8, to be removed from Symfony 3.
      *
      * @return string
      */
     public function getName()
     {
-        return 'elcodi_admin_product_form_type_manufacturer';
+        return $this->getBlockPrefix();
     }
 }

--- a/src/Elcodi/Admin/ProductBundle/Form/Type/ProductType.php
+++ b/src/Elcodi/Admin/ProductBundle/Form/Type/ProductType.php
@@ -206,12 +206,27 @@ class ProductType extends AbstractType
     }
 
     /**
+     * Returns the prefix of the template block name for this type.
+     *
+     * The block prefix defaults to the underscored short class name with
+     * the "Type" suffix removed (e.g. "UserProfileType" => "user_profile").
+     *
+     * @return string The prefix of the template block name
+     */
+    public function getBlockPrefix()
+    {
+        return 'elcodi_admin_product_form_type_product';
+    }
+
+    /**
      * Return unique name for this form
+     *
+     * @deprecated Deprecated since Symfony 2.8, to be removed from Symfony 3.
      *
      * @return string
      */
     public function getName()
     {
-        return 'elcodi_admin_product_form_type_product';
+        return $this->getBlockPrefix();
     }
 }

--- a/src/Elcodi/Admin/ProductBundle/Form/Type/VariantType.php
+++ b/src/Elcodi/Admin/ProductBundle/Form/Type/VariantType.php
@@ -136,12 +136,27 @@ class VariantType extends AbstractType
     }
 
     /**
+     * Returns the prefix of the template block name for this type.
+     *
+     * The block prefix defaults to the underscored short class name with
+     * the "Type" suffix removed (e.g. "UserProfileType" => "user_profile").
+     *
+     * @return string The prefix of the template block name
+     */
+    public function getBlockPrefix()
+    {
+        return 'elcodi_admin_product_form_type_product_variant';
+    }
+
+    /**
      * Return unique name for this form
+     *
+     * @deprecated Deprecated since Symfony 2.8, to be removed from Symfony 3.
      *
      * @return string
      */
     public function getName()
     {
-        return 'elcodi_admin_product_form_type_product_variant';
+        return $this->getBlockPrefix();
     }
 }

--- a/src/Elcodi/Admin/RuleBundle/Form/Type/RuleType.php
+++ b/src/Elcodi/Admin/RuleBundle/Form/Type/RuleType.php
@@ -69,12 +69,27 @@ class RuleType extends AbstractType
     }
 
     /**
+     * Returns the prefix of the template block name for this type.
+     *
+     * The block prefix defaults to the underscored short class name with
+     * the "Type" suffix removed (e.g. "UserProfileType" => "user_profile").
+     *
+     * @return string The prefix of the template block name
+     */
+    public function getBlockPrefix()
+    {
+        return 'elcodi_admin_rule_form_type_rule';
+    }
+
+    /**
      * Return unique name for this form
+     *
+     * @deprecated Deprecated since Symfony 2.8, to be removed from Symfony 3.
      *
      * @return string
      */
     public function getName()
     {
-        return 'elcodi_admin_rule_form_type_rule';
+        return $this->getBlockPrefix();
     }
 }

--- a/src/Elcodi/Admin/StoreBundle/Form/Type/StoreAddressType.php
+++ b/src/Elcodi/Admin/StoreBundle/Form/Type/StoreAddressType.php
@@ -80,12 +80,27 @@ class StoreAddressType extends AbstractType
     }
 
     /**
+     * Returns the prefix of the template block name for this type.
+     *
+     * The block prefix defaults to the underscored short class name with
+     * the "Type" suffix removed (e.g. "UserProfileType" => "user_profile").
+     *
+     * @return string The prefix of the template block name
+     */
+    public function getBlockPrefix()
+    {
+        return 'elcodi_admin_store_form_type_store_address';
+    }
+
+    /**
      * Return unique name for this form
+     *
+     * @deprecated Deprecated since Symfony 2.8, to be removed from Symfony 3.
      *
      * @return string
      */
     public function getName()
     {
-        return 'elcodi_admin_store_form_type_store_address';
+        return $this->getBlockPrefix();
     }
 }

--- a/src/Elcodi/Admin/StoreBundle/Form/Type/StoreCorporateType.php
+++ b/src/Elcodi/Admin/StoreBundle/Form/Type/StoreCorporateType.php
@@ -114,12 +114,27 @@ class StoreCorporateType extends AbstractType
     }
 
     /**
+     * Returns the prefix of the template block name for this type.
+     *
+     * The block prefix defaults to the underscored short class name with
+     * the "Type" suffix removed (e.g. "UserProfileType" => "user_profile").
+     *
+     * @return string The prefix of the template block name
+     */
+    public function getBlockPrefix()
+    {
+        return 'elcodi_admin_store_form_type_store_corporate';
+    }
+
+    /**
      * Return unique name for this form
+     *
+     * @deprecated Deprecated since Symfony 2.8, to be removed from Symfony 3.
      *
      * @return string
      */
     public function getName()
     {
-        return 'elcodi_admin_store_form_type_store_corporate';
+        return $this->getBlockPrefix();
     }
 }

--- a/src/Elcodi/Admin/StoreBundle/Form/Type/StoreSettingsType.php
+++ b/src/Elcodi/Admin/StoreBundle/Form/Type/StoreSettingsType.php
@@ -105,12 +105,27 @@ class StoreSettingsType extends AbstractType
     }
 
     /**
+     * Returns the prefix of the template block name for this type.
+     *
+     * The block prefix defaults to the underscored short class name with
+     * the "Type" suffix removed (e.g. "UserProfileType" => "user_profile").
+     *
+     * @return string The prefix of the template block name
+     */
+    public function getBlockPrefix()
+    {
+        return 'elcodi_admin_store_form_type_store_settings';
+    }
+
+    /**
      * Return unique name for this form
+     *
+     * @deprecated Deprecated since Symfony 2.8, to be removed from Symfony 3.
      *
      * @return string
      */
     public function getName()
     {
-        return 'elcodi_admin_store_form_type_store_settings';
+        return $this->getBlockPrefix();
     }
 }

--- a/src/Elcodi/Admin/UserBundle/Form/Type/AdminUserType.php
+++ b/src/Elcodi/Admin/UserBundle/Form/Type/AdminUserType.php
@@ -100,12 +100,27 @@ class AdminUserType extends AbstractType
     }
 
     /**
+     * Returns the prefix of the template block name for this type.
+     *
+     * The block prefix defaults to the underscored short class name with
+     * the "Type" suffix removed (e.g. "UserProfileType" => "user_profile").
+     *
+     * @return string The prefix of the template block name
+     */
+    public function getBlockPrefix()
+    {
+        return 'elcodi_admin_user_form_type_admin_user';
+    }
+
+    /**
      * Return unique name for this form
+     *
+     * @deprecated Deprecated since Symfony 2.8, to be removed from Symfony 3.
      *
      * @return string
      */
     public function getName()
     {
-        return 'elcodi_admin_user_form_type_admin_user';
+        return $this->getBlockPrefix();
     }
 }

--- a/src/Elcodi/Admin/UserBundle/Form/Type/CustomerType.php
+++ b/src/Elcodi/Admin/UserBundle/Form/Type/CustomerType.php
@@ -124,12 +124,27 @@ class CustomerType extends AbstractType
     }
 
     /**
+     * Returns the prefix of the template block name for this type.
+     *
+     * The block prefix defaults to the underscored short class name with
+     * the "Type" suffix removed (e.g. "UserProfileType" => "user_profile").
+     *
+     * @return string The prefix of the template block name
+     */
+    public function getBlockPrefix()
+    {
+        return 'elcodi_admin_user_form_type_customer';
+    }
+
+    /**
      * Return unique name for this form
+     *
+     * @deprecated Deprecated since Symfony 2.8, to be removed from Symfony 3.
      *
      * @return string
      */
     public function getName()
     {
-        return 'elcodi_admin_user_form_type_customer';
+        return $this->getBlockPrefix();
     }
 }

--- a/src/Elcodi/Admin/UserBundle/Form/Type/LoginType.php
+++ b/src/Elcodi/Admin/UserBundle/Form/Type/LoginType.php
@@ -66,12 +66,27 @@ class LoginType extends AbstractType
     }
 
     /**
+     * Returns the prefix of the template block name for this type.
+     *
+     * The block prefix defaults to the underscored short class name with
+     * the "Type" suffix removed (e.g. "UserProfileType" => "user_profile").
+     *
+     * @return string The prefix of the template block name
+     */
+    public function getBlockPrefix()
+    {
+        return 'elcodi_admin_user_form_type_login';
+    }
+
+    /**
      * Return unique name for this form
+     *
+     * @deprecated Deprecated since Symfony 2.8, to be removed from Symfony 3.
      *
      * @return string
      */
     public function getName()
     {
-        return 'elcodi_admin_user_form_type_login';
+        return $this->getBlockPrefix();
     }
 }

--- a/src/Elcodi/Admin/UserBundle/Form/Type/PasswordRecoverType.php
+++ b/src/Elcodi/Admin/UserBundle/Form/Type/PasswordRecoverType.php
@@ -44,12 +44,27 @@ class PasswordRecoverType extends AbstractType
     }
 
     /**
+     * Returns the prefix of the template block name for this type.
+     *
+     * The block prefix defaults to the underscored short class name with
+     * the "Type" suffix removed (e.g. "UserProfileType" => "user_profile").
+     *
+     * @return string The prefix of the template block name
+     */
+    public function getBlockPrefix()
+    {
+        return 'elcodi_admin_user_form_type_password_recover';
+    }
+
+    /**
      * Return unique name for this form
+     *
+     * @deprecated Deprecated since Symfony 2.8, to be removed from Symfony 3.
      *
      * @return string
      */
     public function getName()
     {
-        return 'elcodi_admin_user_form_type_password_recover';
+        return $this->getBlockPrefix();
     }
 }

--- a/src/Elcodi/Admin/UserBundle/Form/Type/PasswordRememberType.php
+++ b/src/Elcodi/Admin/UserBundle/Form/Type/PasswordRememberType.php
@@ -40,12 +40,27 @@ class PasswordRememberType extends AbstractType
     }
 
     /**
+     * Returns the prefix of the template block name for this type.
+     *
+     * The block prefix defaults to the underscored short class name with
+     * the "Type" suffix removed (e.g. "UserProfileType" => "user_profile").
+     *
+     * @return string The prefix of the template block name
+     */
+    public function getBlockPrefix()
+    {
+        return 'elcodi_admin_user_form_type_password_remember';
+    }
+
+    /**
      * Return unique name for this form
+     *
+     * @deprecated Deprecated since Symfony 2.8, to be removed from Symfony 3.
      *
      * @return string
      */
     public function getName()
     {
-        return 'elcodi_admin_user_form_type_password_remember';
+        return $this->getBlockPrefix();
     }
 }

--- a/src/Elcodi/Admin/UserBundle/Form/Type/ProfileType.php
+++ b/src/Elcodi/Admin/UserBundle/Form/Type/ProfileType.php
@@ -95,12 +95,27 @@ class ProfileType extends AbstractType
     }
 
     /**
+     * Returns the prefix of the template block name for this type.
+     *
+     * The block prefix defaults to the underscored short class name with
+     * the "Type" suffix removed (e.g. "UserProfileType" => "user_profile").
+     *
+     * @return string The prefix of the template block name
+     */
+    public function getBlockPrefix()
+    {
+        return 'elcodi_admin_user_form_type_profile';
+    }
+
+    /**
      * Return unique name for this form
+     *
+     * @deprecated Deprecated since Symfony 2.8, to be removed from Symfony 3.
      *
      * @return string
      */
     public function getName()
     {
-        return 'elcodi_admin_user_form_type_profile';
+        return $this->getBlockPrefix();
     }
 }

--- a/src/Elcodi/Plugin/CustomShippingBundle/Form/Type/CarrierType.php
+++ b/src/Elcodi/Plugin/CustomShippingBundle/Form/Type/CarrierType.php
@@ -96,12 +96,27 @@ class CarrierType extends AbstractType
     }
 
     /**
+     * Returns the prefix of the template block name for this type.
+     *
+     * The block prefix defaults to the underscored short class name with
+     * the "Type" suffix removed (e.g. "UserProfileType" => "user_profile").
+     *
+     * @return string The prefix of the template block name
+     */
+    public function getBlockPrefix()
+    {
+        return 'elcodi_plugin_custom_shipping_form_type_carrier';
+    }
+
+    /**
      * Return unique name for this form
+     *
+     * @deprecated Deprecated since Symfony 2.8, to be removed from Symfony 3.
      *
      * @return string
      */
     public function getName()
     {
-        return 'elcodi_plugin_custom_shipping_form_type_carrier';
+        return $this->getBlockPrefix();
     }
 }

--- a/src/Elcodi/Plugin/CustomShippingBundle/Form/Type/ShippingRangeType.php
+++ b/src/Elcodi/Plugin/CustomShippingBundle/Form/Type/ShippingRangeType.php
@@ -110,12 +110,27 @@ class ShippingRangeType extends AbstractType
     }
 
     /**
+     * Returns the prefix of the template block name for this type.
+     *
+     * The block prefix defaults to the underscored short class name with
+     * the "Type" suffix removed (e.g. "UserProfileType" => "user_profile").
+     *
+     * @return string The prefix of the template block name
+     */
+    public function getBlockPrefix()
+    {
+        return 'elcodi_plugin_custom_shipping_form_type_shipping_range';
+    }
+
+    /**
      * Return unique name for this form
+     *
+     * @deprecated Deprecated since Symfony 2.8, to be removed from Symfony 3.
      *
      * @return string
      */
     public function getName()
     {
-        return 'elcodi_plugin_custom_shipping_form_type_shipping_range';
+        return $this->getBlockPrefix();
     }
 }

--- a/src/Elcodi/Store/CartBundle/Form/Type/CartLineType.php
+++ b/src/Elcodi/Store/CartBundle/Form/Type/CartLineType.php
@@ -69,12 +69,27 @@ class CartLineType extends AbstractType
     }
 
     /**
+     * Returns the prefix of the template block name for this type.
+     *
+     * The block prefix defaults to the underscored short class name with
+     * the "Type" suffix removed (e.g. "UserProfileType" => "user_profile").
+     *
+     * @return string The prefix of the template block name
+     */
+    public function getBlockPrefix()
+    {
+        return 'store_cart_form_type_cart_line';
+    }
+
+    /**
      * Return unique name for this form
+     *
+     * @deprecated Deprecated since Symfony 2.8, to be removed from Symfony 3.
      *
      * @return string
      */
     public function getName()
     {
-        return 'store_cart_form_type_cart_line';
+        return $this->getBlockPrefix();
     }
 }

--- a/src/Elcodi/Store/CartBundle/Form/Type/CartType.php
+++ b/src/Elcodi/Store/CartBundle/Form/Type/CartType.php
@@ -92,12 +92,27 @@ class CartType extends AbstractType
     }
 
     /**
+     * Returns the prefix of the template block name for this type.
+     *
+     * The block prefix defaults to the underscored short class name with
+     * the "Type" suffix removed (e.g. "UserProfileType" => "user_profile").
+     *
+     * @return string The prefix of the template block name
+     */
+    public function getBlockPrefix()
+    {
+        return 'store_cart_form_type_cart';
+    }
+
+    /**
      * Return unique name for this form
+     *
+     * @deprecated Deprecated since Symfony 2.8, to be removed from Symfony 3.
      *
      * @return string
      */
     public function getName()
     {
-        return 'store_cart_form_type_cart';
+        return $this->getBlockPrefix();
     }
 }

--- a/src/Elcodi/Store/CartCouponBundle/Form/Type/CouponApplyType.php
+++ b/src/Elcodi/Store/CartCouponBundle/Form/Type/CouponApplyType.php
@@ -68,12 +68,27 @@ class CouponApplyType extends AbstractType
     }
 
     /**
+     * Returns the prefix of the template block name for this type.
+     *
+     * The block prefix defaults to the underscored short class name with
+     * the "Type" suffix removed (e.g. "UserProfileType" => "user_profile").
+     *
+     * @return string The prefix of the template block name
+     */
+    public function getBlockPrefix()
+    {
+        return 'store_cart_coupon_form_type_coupon_apply';
+    }
+
+    /**
      * Return unique name for this form
+     *
+     * @deprecated Deprecated since Symfony 2.8, to be removed from Symfony 3.
      *
      * @return string
      */
     public function getName()
     {
-        return 'store_cart_coupon_form_type_coupon_apply';
+        return $this->getBlockPrefix();
     }
 }

--- a/src/Elcodi/Store/GeoBundle/Form/Type/AddressType.php
+++ b/src/Elcodi/Store/GeoBundle/Form/Type/AddressType.php
@@ -103,12 +103,27 @@ class AddressType extends AbstractType
     }
 
     /**
+     * Returns the prefix of the template block name for this type.
+     *
+     * The block prefix defaults to the underscored short class name with
+     * the "Type" suffix removed (e.g. "UserProfileType" => "user_profile").
+     *
+     * @return string The prefix of the template block name
+     */
+    public function getBlockPrefix()
+    {
+        return 'store_geo_form_type_address';
+    }
+
+    /**
      * Return unique name for this form
+     *
+     * @deprecated Deprecated since Symfony 2.8, to be removed from Symfony 3.
      *
      * @return string
      */
     public function getName()
     {
-        return 'store_geo_form_type_address';
+        return $this->getBlockPrefix();
     }
 }

--- a/src/Elcodi/Store/UserBundle/Form/Type/LoginType.php
+++ b/src/Elcodi/Store/UserBundle/Form/Type/LoginType.php
@@ -71,12 +71,27 @@ class LoginType extends AbstractType
     }
 
     /**
+     * Returns the prefix of the template block name for this type.
+     *
+     * The block prefix defaults to the underscored short class name with
+     * the "Type" suffix removed (e.g. "UserProfileType" => "user_profile").
+     *
+     * @return string The prefix of the template block name
+     */
+    public function getBlockPrefix()
+    {
+        return 'store_user_form_type_login';
+    }
+
+    /**
      * Return unique name for this form
+     *
+     * @deprecated Deprecated since Symfony 2.8, to be removed from Symfony 3.
      *
      * @return string
      */
     public function getName()
     {
-        return 'store_user_form_type_login';
+        return $this->getBlockPrefix();
     }
 }

--- a/src/Elcodi/Store/UserBundle/Form/Type/PasswordRecoverType.php
+++ b/src/Elcodi/Store/UserBundle/Form/Type/PasswordRecoverType.php
@@ -51,12 +51,27 @@ class PasswordRecoverType extends AbstractType
     }
 
     /**
+     * Returns the prefix of the template block name for this type.
+     *
+     * The block prefix defaults to the underscored short class name with
+     * the "Type" suffix removed (e.g. "UserProfileType" => "user_profile").
+     *
+     * @return string The prefix of the template block name
+     */
+    public function getBlockPrefix()
+    {
+        return 'store_user_form_type_password_recover';
+    }
+
+    /**
      * Return unique name for this form
+     *
+     * @deprecated Deprecated since Symfony 2.8, to be removed from Symfony 3.
      *
      * @return string
      */
     public function getName()
     {
-        return 'store_user_form_type_password_recover';
+        return $this->getBlockPrefix();
     }
 }

--- a/src/Elcodi/Store/UserBundle/Form/Type/PasswordRememberType.php
+++ b/src/Elcodi/Store/UserBundle/Form/Type/PasswordRememberType.php
@@ -45,12 +45,27 @@ class PasswordRememberType extends AbstractType
     }
 
     /**
+     * Returns the prefix of the template block name for this type.
+     *
+     * The block prefix defaults to the underscored short class name with
+     * the "Type" suffix removed (e.g. "UserProfileType" => "user_profile").
+     *
+     * @return string The prefix of the template block name
+     */
+    public function getBlockPrefix()
+    {
+        return 'store_user_form_type_password_remember';
+    }
+
+    /**
      * Return unique name for this form
+     *
+     * @deprecated Deprecated since Symfony 2.8, to be removed from Symfony 3.
      *
      * @return string
      */
     public function getName()
     {
-        return 'store_user_form_type_password_remember';
+        return $this->getBlockPrefix();
     }
 }

--- a/src/Elcodi/Store/UserBundle/Form/Type/ProfileType.php
+++ b/src/Elcodi/Store/UserBundle/Form/Type/ProfileType.php
@@ -87,12 +87,27 @@ class ProfileType extends AbstractType
     }
 
     /**
+     * Returns the prefix of the template block name for this type.
+     *
+     * The block prefix defaults to the underscored short class name with
+     * the "Type" suffix removed (e.g. "UserProfileType" => "user_profile").
+     *
+     * @return string The prefix of the template block name
+     */
+    public function getBlockPrefix()
+    {
+        return 'store_user_form_type_profile';
+    }
+
+    /**
      * Return unique name for this form
+     *
+     * @deprecated Deprecated since Symfony 2.8, to be removed from Symfony 3.
      *
      * @return string
      */
     public function getName()
     {
-        return 'store_user_form_type_profile';
+        return $this->getBlockPrefix();
     }
 }

--- a/src/Elcodi/Store/UserBundle/Form/Type/RegisterType.php
+++ b/src/Elcodi/Store/UserBundle/Form/Type/RegisterType.php
@@ -89,12 +89,27 @@ class RegisterType extends AbstractType
     }
 
     /**
+     * Returns the prefix of the template block name for this type.
+     *
+     * The block prefix defaults to the underscored short class name with
+     * the "Type" suffix removed (e.g. "UserProfileType" => "user_profile").
+     *
+     * @return string The prefix of the template block name
+     */
+    public function getBlockPrefix()
+    {
+        return 'store_user_form_type_register';
+    }
+
+    /**
      * Return unique name for this form
+     *
+     * @deprecated Deprecated since Symfony 2.8, to be removed from Symfony 3.
      *
      * @return string
      */
     public function getName()
     {
-        return 'store_user_form_type_register';
+        return $this->getBlockPrefix();
     }
 }


### PR DESCRIPTION
This is a first step to move defined forms to Symfony 2.8 & 3.

Ref: https://github.com/symfony/symfony/blob/2.8/UPGRADE-2.8.md